### PR TITLE
Fix JsSIP.utils on Chrome

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -92,7 +92,7 @@ JsSIP.utils = {
   },
 
   isWebRtcSupported: function() {
-    if(typeof window.webkitPeerConnection00 === 'undefined'){
+    if(typeof window.webkitRTCPeerConnection === 'undefined'){
       return false;
     } else if(typeof navigator.webkitGetUserMedia === 'undefined'){
       return false;


### PR DESCRIPTION
Chrome 24-dev doesn't have the function webkitPeerConnection00, this patch fix it.
