### PR TITLE
missed return on UA.call

### DIFF
--- a/src/UA.js
+++ b/src/UA.js
@@ -1,4 +1,3 @@
-
 /**
  * @fileoverview SIP User Agent
  */
@@ -147,6 +146,7 @@ JsSIP.UA.prototype.call = function(target, useAudio, useVideo, eventHandlers, vi
 
   session = new JsSIP.Session(this);
   session.connect(target, options);
+  return session;
 };
 
 /**


### PR DESCRIPTION
According to your example
var session = coolPhone.call('sip:bob@example.com', useAudio, useVideo, eventHandlers, views);

UA.call should return session variable, which can be used to terminate the call.
