### PR TITLE
Fix for SIP endpoints starting with "sip"

### DIFF
--- a/src/grammar/dist/grammar.js
+++ b/src/grammar/dist/grammar.js
@@ -2972,7 +2972,7 @@ JsSIP.grammar = (function(){
         var pos0;
         
         pos0 = pos;
-        if (input.substr(pos, 3).toLowerCase() === "sip") {
+        if (input.substr(pos, 4).toLowerCase() === "sip:") {
           result0 = input.substr(pos, 3);
           pos += 3;
         } else {


### PR DESCRIPTION
Currently registrations don't happen if the endpoint username starts with the letters 'sip'
For eg. 
sipadmin@jssip.com

The ERROR being, 

```
MESSAGE | Error parsing "To" header field with value: "sipadmin@jssip.com;tag=b6a60d2210e07fdf58fd2b188ac28a63.c13e" 
```
