### PR TITLE
Added missing 'originator' property to RTCSession 'started' event object

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -1028,6 +1028,7 @@ RTCSession.prototype.started = function(originator, message) {
   session.start_time = new Date();
 
   session.emit(event_name, session, {
+    originator: originator,
     response: message || null
   });
 };


### PR DESCRIPTION
Fix for issue #100
