### PR TITLE
Use a configurable logger object for all logging

### DIFF
--- a/src/Dialogs.js
+++ b/src/Dialogs.js
@@ -16,7 +16,6 @@
 var RequestSender   = @@include('../src/Dialog/RequestSender.js')
 
 var Dialog,
-  LOG_PREFIX = JsSIP.name +' | '+ 'DIALOG' +' | ',
   C = {
     // Dialog states
     STATUS_EARLY:       1,
@@ -27,8 +26,10 @@ var Dialog,
 Dialog = function(owner, message, type, state) {
   var contact;
 
+  this.logger = owner.ua.createLogger('jssip.dialog');
+
   if(!message.hasHeader('contact')) {
-    console.error(LOG_PREFIX +'unable to create a Dialog without Contact header field');
+    this.logger.error('unable to create a Dialog without Contact header field');
     return false;
   }
 
@@ -78,7 +79,7 @@ Dialog = function(owner, message, type, state) {
 
   this.owner = owner;
   owner.ua.dialogs[this.id.toString()] = this;
-  console.log(LOG_PREFIX +'new ' + type + ' dialog created with status ' + (this.state === C.STATUS_EARLY ? 'EARLY': 'CONFIRMED'));
+  this.logger.log('new ' + type + ' dialog created with status ' + (this.state === C.STATUS_EARLY ? 'EARLY': 'CONFIRMED'));
 };
 
 Dialog.prototype = {
@@ -89,7 +90,7 @@ Dialog.prototype = {
   update: function(message, type) {
     this.state = C.STATUS_CONFIRMED;
 
-    console.log(LOG_PREFIX +'dialog '+ this.id.toString() +'  changed to CONFIRMED state');
+    this.logger.log('dialog '+ this.id.toString() +'  changed to CONFIRMED state');
 
     if(type === 'UAC') {
       // RFC 3261 13.2.2.4
@@ -98,7 +99,7 @@ Dialog.prototype = {
   },
 
   terminate: function() {
-    console.log(LOG_PREFIX +'dialog ' + this.id.toString() + ' deleted');
+    this.logger.log('dialog ' + this.id.toString() + ' deleted');
     delete this.owner.ua.dialogs[this.id.toString()];
   },
 

--- a/src/DigestAuthentication.js
+++ b/src/DigestAuthentication.js
@@ -10,10 +10,10 @@
  * @param {JsSIP.UA} ua
  */
 (function(JsSIP) {
-var DigestAuthentication,
-  LOG_PREFIX = JsSIP.name +' | '+ 'DIGEST AUTHENTICATION' +' | ';
+var DigestAuthentication;
 
 DigestAuthentication = function(ua) {
+  this.logger = ua.createLogger('jssip.digestauth');
   this.username = ua.configuration.authorization_user;
   this.password = ua.configuration.password;
   this.cnonce = null;
@@ -42,7 +42,7 @@ DigestAuthentication.prototype.authenticate = function(request, challenge) {
 
   if (this.algorithm) {
     if (this.algorithm !== 'MD5') {
-      console.warn(LOG_PREFIX + 'challenge with Digest algorithm different than "MD5", authentication aborted');
+      this.logger.warn('challenge with Digest algorithm different than "MD5", authentication aborted');
       return false;
     }
   } else {
@@ -50,12 +50,12 @@ DigestAuthentication.prototype.authenticate = function(request, challenge) {
   }
 
   if (! this.realm) {
-    console.warn(LOG_PREFIX + 'challenge without Digest realm, authentication aborted');
+    this.logger.warn('challenge without Digest realm, authentication aborted');
     return false;
   }
 
   if (! this.nonce) {
-    console.warn(LOG_PREFIX + 'challenge without Digest nonce, authentication aborted');
+    this.logger.warn('challenge without Digest nonce, authentication aborted');
     return false;
   }
 
@@ -67,7 +67,7 @@ DigestAuthentication.prototype.authenticate = function(request, challenge) {
       this.qop = 'auth-int';
     } else {
       // Otherwise 'qop' is present but does not contain 'auth' or 'auth-int', so abort here.
-      console.warn(LOG_PREFIX + 'challenge without Digest qop different than "auth" or "auth-int", authentication aborted');
+      this.logger.warn('challenge without Digest qop different than "auth" or "auth-int", authentication aborted');
       return false;
     }
   } else {

--- a/src/EventEmitter.js
+++ b/src/EventEmitter.js
@@ -10,7 +10,6 @@
 var
   EventEmitter,
   Event,
-  LOG_PREFIX = JsSIP.name +' | '+ 'EVENT EMITTER' +' | ',
   C = {
     MAX_LISTENERS: 10
   };
@@ -30,7 +29,7 @@ EventEmitter.prototype = {
     this.oneTimeListeners = {};
 
     for (idx in events) {
-      console.log(LOG_PREFIX +'adding event '+ events[idx]);
+      this.logger.log('adding event '+ events[idx]);
       this.events[events[idx]] = [];
       this.oneTimeListeners[events[idx]] = [];
     }
@@ -54,19 +53,19 @@ EventEmitter.prototype = {
     if (listener === undefined) {
       return;
     } else if (typeof listener !== 'function') {
-      console.error('listener must be a function');
+      this.logger.error('listener must be a function');
       return;
     } else if (!this.checkEvent(event)) {
-      console.error(LOG_PREFIX +'unable to add a listener to a nonexistent event'+ event);
+      this.logger.error('unable to add a listener to a nonexistent event'+ event);
       return;
     }
 
     if (this.events[event].length >= this.maxListeners) {
-      console.warn(LOG_PREFIX +'max listeners exceeded for event '+ event);
+      this.logger.warn('max listeners exceeded for event '+ event);
     }
 
     this.events[event].push(listener);
-    console.log(LOG_PREFIX +'new listener added to event '+ event);
+    this.logger.log('new listener added to event '+ event);
   },
 
   on: function(event, listener) {
@@ -97,9 +96,9 @@ EventEmitter.prototype = {
     if (listener === undefined) {
       return;
     } else if (typeof listener !== 'function') {
-      console.error('listener must be a function');
+      this.logger.error('listener must be a function');
     } else if (!this.checkEvent(event)) {
-      console.error(LOG_PREFIX +'unable to remove a listener from a nonexistent event'+ event);
+      this.logger.error('unable to remove a listener from a nonexistent event'+ event);
       return;
     }
 
@@ -121,7 +120,7 @@ EventEmitter.prototype = {
   */
   removeAllListener: function(event) {
     if (!this.checkEvent(event)) {
-      console.error(LOG_PREFIX +'unable to remove listeners from a nonexistent event'+ event);
+      this.logger.error('unable to remove listeners from a nonexistent event'+ event);
       return;
     }
 
@@ -137,7 +136,7 @@ EventEmitter.prototype = {
   */
   setMaxListeners: function(listeners) {
     if (typeof listeners !== 'number' || listeners < 0) {
-      console.error('listeners must be a positive number');
+      this.logger.error('listeners must be a positive number');
       return;
     }
 
@@ -151,7 +150,7 @@ EventEmitter.prototype = {
   */
   listeners: function(event) {
     if (!this.checkEvent(event)) {
-      console.error(LOG_PREFIX +'no event '+ event);
+      this.logger.error('no event '+ event);
       return;
     }
 
@@ -167,11 +166,11 @@ EventEmitter.prototype = {
     var listeners, idx, e;
 
     if (!this.checkEvent(event)) {
-      console.error(LOG_PREFIX +'unable to emit a nonexistent event'+ event);
+      this.logger.error('unable to emit a nonexistent event'+ event);
       return;
     }
 
-    console.log(LOG_PREFIX +'emitting event '+ event);
+    this.logger.log('emitting event '+ event);
 
     e = new JsSIP.Event(event, sender, data);
 
@@ -181,7 +180,7 @@ EventEmitter.prototype = {
       try {
         listeners[idx].apply(null, [e]);
       } catch(err) {
-        console.error(err.stack);
+        this.logger.error(err.stack);
       }
     }
 

--- a/src/Message.js
+++ b/src/Message.js
@@ -12,6 +12,7 @@ var Message;
 
 Message = function(ua) {
   this.ua = ua;
+  this.logger = ua.createLogger('jssip.message');
   this.direction = null;
   this.local_identity = null;
   this.remote_identity = null;

--- a/src/Parser.js
+++ b/src/Parser.js
@@ -8,8 +8,7 @@
  * @namespace
  */
 (function(JsSIP) {
-var Parser,
-  LOG_PREFIX = JsSIP.name +' | '+ 'PARSER' +' | ';
+var Parser;
 
 function getHeader(data, headerStart) {
   var
@@ -167,16 +166,17 @@ function parseHeader(message, data, headerStart, headerEnd) {
 /** Parse SIP Message
  * @function
  * @param {String} message SIP message.
+ * @param {Object} logger object.
  * @returns {JsSIP.IncomingRequest|JsSIP.IncomingResponse|undefined}
  */
 Parser = {};
-Parser.parseMessage = function(data) {
+Parser.parseMessage = function(data, logger) {
   var message, firstLine, contentLength, bodyStart, parsed,
     headerStart = 0,
     headerEnd = data.indexOf('\r\n');
 
   if(headerEnd === -1) {
-    console.warn(LOG_PREFIX +'no CRLF found, not a SIP message, discarded');
+    logger.warn('no CRLF found, not a SIP message, discarded');
     return;
   }
 
@@ -185,7 +185,7 @@ Parser.parseMessage = function(data) {
   parsed = JsSIP.Grammar.parse(firstLine, 'Request_Response');
 
   if(parsed === -1) {
-    console.warn(LOG_PREFIX +'error parsing first line of SIP message: "' + firstLine + '"');
+    logger.warn('error parsing first line of SIP message: "' + firstLine + '"');
     return;
   } else if(!parsed.status_code) {
     message = new JsSIP.IncomingRequest();

--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -14,7 +14,6 @@ var RTCMediaHandler = @@include('../src/RTCSession/RTCMediaHandler.js')
 var DTMF            = @@include('../src/RTCSession/DTMF.js')
 
 var RTCSession,
-  LOG_PREFIX = JsSIP.name +' | '+ 'RTC SESSION' +' | ',
   C = {
     // RTCSession states
     STATUS_NULL:               0,
@@ -38,6 +37,7 @@ RTCSession = function(ua) {
   'newDTMF'
   ];
 
+  this.logger = ua.createLogger('jssip.rtcsession');
   this.ua = ua;
   this.status = C.STATUS_NULL;
   this.dialog = null;
@@ -94,7 +94,7 @@ RTCSession.prototype.terminate = function(options) {
     case C.STATUS_NULL:
     case C.STATUS_INVITE_SENT:
     case C.STATUS_1XX_RECEIVED:
-      console.log(LOG_PREFIX +'canceling RTCSession');
+      this.logger.log('canceling RTCSession');
 
       if (status_code && (status_code < 200 || status_code >= 700)) {
         throw new TypeError('Invalid status_code: '+ status_code);
@@ -123,7 +123,7 @@ RTCSession.prototype.terminate = function(options) {
 
       // - UAS -
     case C.STATUS_WAITING_FOR_ANSWER:
-      console.log(LOG_PREFIX +'rejecting RTCSession');
+      this.logger.log('rejecting RTCSession');
 
       status_code = status_code || 480;
 
@@ -136,7 +136,7 @@ RTCSession.prototype.terminate = function(options) {
       break;
     case C.STATUS_WAITING_FOR_ACK:
     case C.STATUS_CONFIRMED:
-      console.log(LOG_PREFIX +'terminating RTCSession');
+      this.logger.log('terminating RTCSession');
 
       reason_phrase = options.reason_phrase || JsSIP.C.REASON_PHRASE[status_code] || '';
 
@@ -245,7 +245,7 @@ RTCSession.prototype.answer = function(options) {
            */
           self.timers.ackTimer = window.setTimeout(function() {
               if(self.status === C.STATUS_WAITING_FOR_ACK) {
-                console.log(LOG_PREFIX + 'no ACK received, terminating the call');
+                self.logger.log('no ACK received, terminating the call');
                 window.clearTimeout(self.timers.invite2xxTimer);
                 self.sendRequest(JsSIP.C.BYE);
                 self.ended('remote', null, JsSIP.C.causes.NO_ACK);
@@ -340,7 +340,7 @@ RTCSession.prototype.sendDTMF = function(tones, options) {
   } else if (!interToneGap) {
     interToneGap = DTMF.C.DEFAULT_INTER_TONE_GAP;
   } else if (interToneGap < DTMF.C.MIN_INTER_TONE_GAP) {
-    console.warn(LOG_PREFIX +'"interToneGap" value is lower than the minimum allowed, setting it to '+ DTMF.C.MIN_INTER_TONE_GAP +' milliseconds');
+    this.logger.warn('"interToneGap" value is lower than the minimum allowed, setting it to '+ DTMF.C.MIN_INTER_TONE_GAP +' milliseconds');
     interToneGap = DTMF.C.MIN_INTER_TONE_GAP;
   } else {
     interToneGap = Math.abs(interToneGap);
@@ -487,8 +487,8 @@ RTCSession.prototype.init_incoming = function(request) {
      * Bad media description
      */
     function(e) {
-      console.warn(LOG_PREFIX +'invalid SDP');
-      console.warn(e);
+      self.logger.warn('invalid SDP');
+      self.logger.warn(e);
       request.reply(488);
     }
   );
@@ -584,7 +584,7 @@ RTCSession.prototype.close = function() {
     return;
   }
 
-  console.log(LOG_PREFIX +'closing INVITE session ' + this.id);
+  this.logger.log('closing INVITE session ' + this.id);
 
   // 1st Step. Terminate media.
   if (this.rtcMediaHandler){
@@ -718,7 +718,7 @@ RTCSession.prototype.receiveRequest = function(request) {
         break;
       case JsSIP.C.INVITE:
         if(this.status === C.STATUS_CONFIRMED) {
-          console.log(LOG_PREFIX +'re-INVITE received');
+          this.logger.log('re-INVITE received');
         }
         break;
       case JsSIP.C.INFO:
@@ -833,7 +833,7 @@ RTCSession.prototype.receiveResponse = function(response) {
     case /^1[0-9]{2}$/.test(response.status_code):
       // Do nothing with 1xx responses without To tag.
       if(!response.to_tag) {
-        console.warn(LOG_PREFIX +'1xx response received without to tag');
+        this.logger.warn('1xx response received without to tag');
         break;
       }
 
@@ -880,7 +880,7 @@ RTCSession.prototype.receiveResponse = function(response) {
          * SDP Answer does not fit the Offer. Accept the call and Terminate.
          */
         function(e) {
-          console.warn(e);
+          session.logger.warn(e);
           session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
           session.failed('remote', response, JsSIP.C.causes.BAD_MEDIA_DESCRIPTION);
         }

--- a/src/RTCSession/DTMF.js
+++ b/src/RTCSession/DTMF.js
@@ -23,6 +23,7 @@ DTMF = function(session) {
   'failed'
   ];
 
+  this.logger = session.ua.createLogger('jssip.rtcsession.dtmf');
   this.owner = session;
   this.direction = null;
   this.tone = null;
@@ -75,10 +76,10 @@ DTMF.prototype.send = function(tone, options) {
   } else if (!options.duration) {
     options.duration = C.DEFAULT_DURATION;
   } else if (options.duration < C.MIN_DURATION) {
-    console.warn(LOG_PREFIX +'"duration" value is lower than the minimum allowed, setting it to '+ C.MIN_DURATION+ ' milliseconds');
+    this.logger.warn('"duration" value is lower than the minimum allowed, setting it to '+ C.MIN_DURATION+ ' milliseconds');
     options.duration = C.MIN_DURATION;
   } else if (options.duration > C.MAX_DURATION) {
-    console.warn(LOG_PREFIX +'"duration" value is greater than the maximum allowed, setting it to '+ C.MAX_DURATION +' milliseconds');
+    this.logger.warn('"duration" value is greater than the maximum allowed, setting it to '+ C.MAX_DURATION +' milliseconds');
     options.duration = C.MAX_DURATION;
   } else {
     options.duration = Math.abs(options.duration);
@@ -196,7 +197,7 @@ DTMF.prototype.init_incoming = function(request) {
   }
 
   if (!this.tone || !this.duration) {
-    console.warn(LOG_PREFIX +'invalid INFO DTMF received, discarded');
+    this.logger.warn('invalid INFO DTMF received, discarded');
   } else {
     this.owner.emit('newDTMF', this.owner, {
       originator: 'remote',

--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -12,6 +12,7 @@
 var RTCMediaHandler = function(session, constraints) {
   constraints = constraints || {};
 
+  this.logger = session.ua.createLogger('jssip.rtcserssion.mediahandler');
   this.session = session;
   this.localMedia = null;
   this.peerConnection = null;
@@ -41,8 +42,8 @@ RTCMediaHandler.prototype = {
         );
       },
       function(e) {
-        console.error(LOG_PREFIX +'unable to create offer');
-        console.error(e);
+        self.logger.error('unable to create offer');
+        self.logger.error(e);
         onFailure();
       }
     );
@@ -68,20 +69,22 @@ RTCMediaHandler.prototype = {
         );
       },
       function(e) {
-        console.error(LOG_PREFIX +'unable to create answer');
-        console.error(e);
+        self.logger.error('unable to create answer');
+        self.logger.error(e);
         onFailure();
       }
     );
   },
 
   setLocalDescription: function(sessionDescription, onFailure) {
+    var self = this;
+
     this.peerConnection.setLocalDescription(
       sessionDescription,
       null,
       function(e) {
-        console.error(LOG_PREFIX +'unable to set local description');
-        console.error(e);
+        self.logger.error('unable to set local description');
+        self.logger.error(e);
         onFailure();
       }
     );
@@ -91,8 +94,8 @@ RTCMediaHandler.prototype = {
     try {
       this.peerConnection.addStream(stream, constraints);
     } catch(e) {
-      console.error(LOG_PREFIX +'error adding stream');
-      console.error(e);
+      this.logger.error('error adding stream');
+      this.logger.error(e);
       onFailure();
       return;
     }
@@ -127,16 +130,16 @@ RTCMediaHandler.prototype = {
     this.peerConnection = new JsSIP.WebRTC.RTCPeerConnection({'iceServers': servers}, constraints);
 
     this.peerConnection.onaddstream = function(e) {
-      console.log(LOG_PREFIX +'stream added: '+ e.stream.id);
+      self.logger.log('stream added: '+ e.stream.id);
     };
 
     this.peerConnection.onremovestream = function(e) {
-      console.log(LOG_PREFIX +'stream removed: '+ e.stream.id);
+      self.logger.log('stream removed: '+ e.stream.id);
     };
 
     this.peerConnection.onicecandidate = function(e) {
       if (e.candidate) {
-        console.log(LOG_PREFIX +'ICE candidate received: '+ e.candidate.candidate);
+        self.logger.log('ICE candidate received: '+ e.candidate.candidate);
       } else {
         self.onIceCompleted();
       }
@@ -150,16 +153,16 @@ RTCMediaHandler.prototype = {
     };
 
     this.peerConnection.onicechange = function() {
-      console.log(LOG_PREFIX +'ICE connection state changed to "'+ this.iceConnectionState +'"');
+      self.logger.log('ICE connection state changed to "'+ this.iceConnectionState +'"');
     };
 
     this.peerConnection.onstatechange = function() {
-      console.log(LOG_PREFIX +'PeerConnection state changed to "'+ this.readyState +'"');
+      self.logger.log('PeerConnection state changed to "'+ this.readyState +'"');
     };
   },
 
   close: function() {
-    console.log(LOG_PREFIX + 'closing PeerConnection');
+    this.logger.log('closing PeerConnection');
     if(this.peerConnection) {
       this.peerConnection.close();
 
@@ -177,17 +180,17 @@ RTCMediaHandler.prototype = {
   getUserMedia: function(onSuccess, onFailure, constraints) {
     var self = this;
 
-    console.log(LOG_PREFIX + 'requesting access to local media');
+    this.logger.log('requesting access to local media');
 
     JsSIP.WebRTC.getUserMedia(constraints,
       function(stream) {
-        console.log(LOG_PREFIX + 'got local media stream');
+        self.logger.log('got local media stream');
         self.localMedia = stream;
         onSuccess(stream);
       },
       function(e) {
-        console.error(LOG_PREFIX +'unable to get user media');
-        console.error(e);
+        self.logger.error('unable to get user media');
+        self.logger.error(e);
         onFailure();
       }
     );

--- a/src/RTCSession/Request.js
+++ b/src/RTCSession/Request.js
@@ -17,6 +17,7 @@ var Request = function(session) {
 
   this.owner = session;
 
+  this.logger = session.ua.createLogger('jssip.rtcsession.request');
   this.initEvents(events);
 };
 Request.prototype = new JsSIP.EventEmitter();

--- a/src/Registrator.js
+++ b/src/Registrator.js
@@ -9,11 +9,12 @@
  * @param {JsSIP.Transport} transport
  */
 (function(JsSIP) {
-var Registrator,
-  LOG_PREFIX = JsSIP.name +' | '+ 'REGISTRATOR' +' | ';
+var Registrator;
 
 Registrator = function(ua, transport) {
   var reg_id=1; //Force reg_id to 1.
+
+  this.logger = ua.createLogger('jssip.registrator');
 
   this.ua = ua;
   this.transport = transport;
@@ -93,7 +94,7 @@ Registrator.prototype = {
 
           // Search the Contact pointing to us and update the expires value accordingly.
           if (!contacts) {
-            console.warn(LOG_PREFIX +'no Contact header in response to REGISTER, response ignored');
+            this.logger.warn('no Contact header in response to REGISTER, response ignored');
             break;
           }
 
@@ -108,7 +109,7 @@ Registrator.prototype = {
           }
 
           if (!contact) {
-            console.warn(LOG_PREFIX +'no Contact header pointing to us, response ignored');
+            this.logger.warn('no Contact header pointing to us, response ignored');
             break;
           }
 
@@ -144,7 +145,7 @@ Registrator.prototype = {
               self.register();
             }, this.expires * 1000);
           } else { //This response MUST contain a Min-Expires header field
-            console.warn(LOG_PREFIX +'423 response received for REGISTER without Min-Expires');
+            this.logger.warn('423 response received for REGISTER without Min-Expires');
             this.registrationFailure(response, JsSIP.C.causes.SIP_FAILURE_CODE);
           }
           break;
@@ -178,7 +179,7 @@ Registrator.prototype = {
     var extraHeaders;
 
     if(!this.registered) {
-      console.warn(LOG_PREFIX +'already unregistered');
+      this.logger.warn('already unregistered');
       return;
     }
 

--- a/src/RequestSender.js
+++ b/src/RequestSender.js
@@ -10,10 +10,10 @@
  * @param {JsSIP.UA} ua
  */
 (function(JsSIP) {
-var RequestSender,
-  LOG_PREFIX = JsSIP.name +' | '+ 'REQUEST SENDER' +' | ';
+var RequestSender;
 
 RequestSender = function(applicant, ua) {
+  this.logger = ua.createLogger('jssip.requestsender');
   this.ua = ua;
   this.applicant = applicant;
   this.method = applicant.request.method;
@@ -90,7 +90,7 @@ RequestSender.prototype = {
 
       // Verify it seems a valid challenge.
       if (! challenge) {
-        console.warn(LOG_PREFIX + response.status_code + ' with wrong or missing challenge, cannot authenticate');
+        this.logger.warn(response.status_code + ' with wrong or missing challenge, cannot authenticate');
         this.applicant.receiveResponse(response);
         return;
       }

--- a/src/SIPMessage.js
+++ b/src/SIPMessage.js
@@ -7,8 +7,7 @@ var
   OutgoingRequest,
   IncomingMessage,
   IncomingRequest,
-  IncomingResponse,
-  LOG_PREFIX = JsSIP.name +' | '+ 'SIP MESSAGE' +' | ';
+  IncomingResponse;
 
 /**
  * @augments JsSIP
@@ -36,6 +35,7 @@ OutgoingRequest = function(method, ruri, ua, params, extraHeaders, body) {
     return null;
   }
 
+  this.logger = ua.createLogger('jssip.sipmessage');
   this.headers = {};
   this.method = method;
   this.ruri = ruri;
@@ -228,10 +228,10 @@ IncomingMessage.prototype = {
     idx = idx || 0;
 
     if(!this.headers[name]) {
-      console.log(LOG_PREFIX +'header "' + name + '" not present');
+      this.logger.log('header "' + name + '" not present');
       return;
     } else if(idx >= this.headers[name].length) {
-      console.log(LOG_PREFIX +'not so many "' + name + '" headers present');
+      this.logger.log('not so many "' + name + '" headers present');
       return;
     }
 
@@ -247,7 +247,7 @@ IncomingMessage.prototype = {
 
     if(parsed === -1) {
       this.headers[name].splice(idx, 1); //delete from headers
-      console.warn(LOG_PREFIX +'error parsing "' + name + '" header field with value "' + value + '"');
+      this.logger.warn('error parsing "' + name + '" header field with value "' + value + '"');
       return;
     } else {
       header.parsed = parsed;

--- a/src/SanityCheck.js
+++ b/src/SanityCheck.js
@@ -13,8 +13,7 @@
  */
 (function(JsSIP) {
 var sanityCheck,
- LOG_PREFIX = JsSIP.name +' | '+ 'SANITY CHECK' +' | ',
-
+ logger,
  message, ua, transport,
  requests = [],
  responses = [],
@@ -107,7 +106,7 @@ function rfc3261_8_2_2_2() {
 // Sanity Check functions for responses
 function rfc3261_8_1_3_3() {
   if(message.getHeaders('via').length > 1) {
-    console.warn(LOG_PREFIX +'More than one Via header field present in the response. Dropping the response');
+    logger.warn('More than one Via header field present in the response. Dropping the response');
     return false;
   }
 }
@@ -115,7 +114,7 @@ function rfc3261_8_1_3_3() {
 function rfc3261_18_1_2() {
   var via_host = ua.configuration.via_host;
   if(message.via.host !== via_host) {
-    console.warn(LOG_PREFIX +'Via host in the response does not match UA Via host value. Dropping the response');
+    logger.warn('Via host in the response does not match UA Via host value. Dropping the response');
     return false;
   }
 }
@@ -126,7 +125,7 @@ function rfc3261_18_3_response() {
     contentLength = message.getHeader('content-length');
 
     if(len < contentLength) {
-      console.warn(LOG_PREFIX +'Message body length is lower than the value in Content-Length header field. Dropping the response');
+      logger.warn('Message body length is lower than the value in Content-Length header field. Dropping the response');
       return false;
     }
 }
@@ -139,7 +138,7 @@ function minimumHeaders() {
 
   while(idx--) {
     if(!message.hasHeader(mandatoryHeaders[idx])) {
-      console.warn(LOG_PREFIX +'Missing mandatory header field : '+ mandatoryHeaders[idx] +'. Dropping the response');
+      logger.warn('Missing mandatory header field : '+ mandatoryHeaders[idx] +'. Dropping the response');
       return false;
     }
   }
@@ -189,6 +188,8 @@ sanityCheck = function(m, u, t) {
   message = m;
   ua = u;
   transport = t;
+
+  logger = ua.createLogger('jssip.sanitycheck');
 
   len = all.length;
   while(len--) {

--- a/src/Subscriber.js
+++ b/src/Subscriber.js
@@ -9,7 +9,10 @@
  * @class Class creating a SIP Subscriber.
  */
 
-JsSIP.Subscriber = function() {};
+JsSIP.Subscriber = function(ua) {
+  this.logger = ua.createLogger('jssip.subscriber')
+};
+
 JsSIP.Subscriber.prototype = {
   /**
    * @private
@@ -33,7 +36,7 @@ JsSIP.Subscriber.prototype = {
     var subscription;
 
     if (this.state !== 'terminated') {
-      console.log(JsSIP.C.LOG_SUBSCRIBER,'terminating Subscriber');
+      this.logger.log('terminating Subscriber');
 
       this.state = 'terminated';
       window.clearTimeout(this.N);
@@ -65,7 +68,7 @@ JsSIP.Subscriber.prototype = {
     var subscriber, from_tag, expires;
 
     if (['notify_wait', 'pending', 'active', 'terminated'].indexOf(this.state) !== -1) {
-      console.error(JsSIP.C.LOG_SUBSCRIBER,'subscription is already on');
+      this.logger.error('subscription is already on');
       return;
     }
 
@@ -98,10 +101,10 @@ JsSIP.Subscriber.prototype = {
               subscriber.close();
 
               if (!expires) {
-                console.warn(JsSIP.C.LOG_SUBSCRIBER,'Expires header missing in a 200-class response to SUBSCRIBE');
+                this.logger.warn('Expires header missing in a 200-class response to SUBSCRIBE');
                 subscriber.onFailure(null, JsSIP.C.EXPIRES_HEADER_MISSING);
               } else {
-                console.warn(JsSIP.C.LOG_SUBSCRIBER,'Expires header in a 200-class response to SUBSCRIBE with a higher value than the indicated in the request');
+                this.logger.warn('Expires header in a 200-class response to SUBSCRIBE with a higher value than the indicated in the request');
                 subscriber.onFailure(null, JsSIP.C.INVALID_EXPIRES_HEADER);
               }
             }
@@ -179,7 +182,7 @@ JsSIP.Subscriber.prototype = {
         break;
       case 'terminated':
         if (subscription_state.reason) {
-          console.log(JsSIP.C.LOG_SUBSCRIBER,'terminating subscription with reason '+ subscription_state.reason);
+          this.logger.log('terminating subscription with reason '+ subscription_state.reason);
         }
         window.clearTimeout(this.N);
         this.close();
@@ -195,12 +198,12 @@ JsSIP.Subscriber.prototype = {
 
     // Check mandatory header Event
     if (!request.hasHeader('Event')) {
-      console.warn(JsSIP.C.LOG_SUBSCRIBER,'missing Event header');
+      this.logger.warn('missing Event header');
       return false;
     }
     // Check mandatory header Subscription-State
     if (!request.hasHeader('Subscription-State')) {
-      console.warn(JsSIP.C.LOG_SUBSCRIBER,'missing Subscription-State header');
+      this.logger.warn('missing Subscription-State header');
       return false;
     }
 
@@ -208,7 +211,7 @@ JsSIP.Subscriber.prototype = {
     event = request.s('event').event;
 
     if (this.event !== event) {
-      console.warn(JsSIP.C.LOG_SUBSCRIBER,'event match failed');
+      this.logger.warn('event match failed');
       request.reply(481, 'Event Match Failed');
       return false;
     } else {
@@ -316,7 +319,7 @@ JsSIP.Subscription.prototype = {
       subscription = this;
 
     if (!initial && !this.subscriber.matchEvent(request)) {
-      console.warn(JsSIP.C.LOG_SUBSCRIBER,'NOTIFY request does not match event');
+      this.logger.warn('NOTIFY request does not match event');
       return;
     }
 
@@ -341,7 +344,7 @@ JsSIP.Subscription.prototype = {
         break;
       case 'terminated':
         if (subscription_state.reason) {
-          console.log(JsSIP.C.LOG_SUBSCRIBER,'terminating subscription with reason '+ subscription_state.reason);
+          this.logger.log('terminating subscription with reason '+ subscription_state.reason);
         }
         this.close();
         this.subscriber.receiveInfo(request);
@@ -379,10 +382,10 @@ JsSIP.Subscription.prototype = {
                 subscription.close();
 
                 if (!expires) {
-                  console.warn(JsSIP.C.LOG_SUBSCRIBER,'Expires header missing in a 200-class response to SUBSCRIBE');
+                  this.logger.warn('Expires header missing in a 200-class response to SUBSCRIBE');
                   subscription.subscriber.onFailure(null, JsSIP.C.EXPIRES_HEADER_MISSING);
                 } else {
-                  console.warn(JsSIP.C.LOG_SUBSCRIBER,'Expires header in a 200-class response to SUBSCRIBE with a higher value than the indicated in the request');
+                  this.logger.warn('Expires header in a 200-class response to SUBSCRIBE with a higher value than the indicated in the request');
                   subscription.subscriber.onFailure(null, JsSIP.C.INVALID_EXPIRES_HEADER);
                 }
               }

--- a/src/Transactions.js
+++ b/src/Transactions.js
@@ -8,7 +8,6 @@
  */
 (function(JsSIP) {
 var
-  LOG_PREFIX =  JsSIP.name +' | '+ 'TRANSACTION' +' | ',
   C = {
     // Transaction states
     STATUS_TRYING:     1,
@@ -36,6 +35,8 @@ var
 var NonInviteClientTransaction = function(request_sender, request, transport) {
   var via,
     events = ['stateChanged'];
+
+  this.logger = request_sender.ua.createLogger('jssip.transaction');
 
   this.type = C.NON_INVITE_CLIENT;
   this.transport = transport;
@@ -71,7 +72,7 @@ NonInviteClientTransaction.prototype.send = function() {
 };
 
 NonInviteClientTransaction.prototype.onTransportError = function() {
-  console.log(LOG_PREFIX +'transport error occurred, deleting non-INVITE client transaction ' + this.id);
+  this.logger.log('transport error occurred, deleting non-INVITE client transaction ' + this.id);
   window.clearTimeout(this.F);
   window.clearTimeout(this.K);
   this.request_sender.ua.destroyTransaction(this);
@@ -79,7 +80,7 @@ NonInviteClientTransaction.prototype.onTransportError = function() {
 };
 
 NonInviteClientTransaction.prototype.timer_F = function() {
-  console.log(LOG_PREFIX +'Timer F expired for non-INVITE client transaction ' + this.id);
+  this.logger.log('Timer F expired for non-INVITE client transaction ' + this.id);
   this.stateChanged(C.STATUS_TERMINATED);
   this.request_sender.onRequestTimeout();
   this.request_sender.ua.destroyTransaction(this);
@@ -138,6 +139,8 @@ var InviteClientTransaction = function(request_sender, request, transport) {
     tr = this,
     events = ['stateChanged'];
 
+  this.logger = request_sender.ua.createLogger('jssip.transaction');
+
   this.type = C.INVITE_CLIENT;
   this.transport = transport;
   this.id = 'z9hG4bK' + Math.floor(Math.random() * 10000000);
@@ -179,7 +182,7 @@ InviteClientTransaction.prototype.send = function() {
 };
 
 InviteClientTransaction.prototype.onTransportError = function() {
-  console.log(LOG_PREFIX +'transport error occurred, deleting INVITE client transaction ' + this.id);
+  this.logger.log('transport error occurred, deleting INVITE client transaction ' + this.id);
   window.clearTimeout(this.B);
   window.clearTimeout(this.D);
   window.clearTimeout(this.M);
@@ -192,7 +195,7 @@ InviteClientTransaction.prototype.onTransportError = function() {
 
 // RFC 6026 7.2
 InviteClientTransaction.prototype.timer_M = function() {
-  console.log(LOG_PREFIX +'Timer M expired for INVITE client transaction ' + this.id);
+  this.logger.log('Timer M expired for INVITE client transaction ' + this.id);
 
   if(this.state === C.STATUS_ACCEPTED) {
     this.stateChanged(C.STATUS_TERMINATED);
@@ -203,7 +206,7 @@ InviteClientTransaction.prototype.timer_M = function() {
 
 // RFC 3261 17.1.1
 InviteClientTransaction.prototype.timer_B = function() {
-  console.log(LOG_PREFIX +'Timer B expired for INVITE client transaction ' + this.id);
+  this.logger.log('Timer B expired for INVITE client transaction ' + this.id);
   if(this.state === C.STATUS_CALLING) {
     this.stateChanged(C.STATUS_TERMINATED);
     this.request_sender.onRequestTimeout();
@@ -212,7 +215,7 @@ InviteClientTransaction.prototype.timer_B = function() {
 };
 
 InviteClientTransaction.prototype.timer_D = function() {
-  console.log(LOG_PREFIX +'Timer D expired for INVITE client transaction ' + this.id);
+  this.logger.log('Timer D expired for INVITE client transaction ' + this.id);
   this.stateChanged(C.STATUS_TERMINATED);
   window.clearTimeout(this.B);
   this.request_sender.ua.destroyTransaction(this);
@@ -325,6 +328,8 @@ InviteClientTransaction.prototype.receiveResponse = function(response) {
 var AckClientTransaction = function(request_sender, request, transport) {
   var via;
 
+  this.logger = request_sender.ua.createLogger('jssip.transaction');
+
   this.transport = transport;
   this.id = 'z9hG4bK' + Math.floor(Math.random() * 10000000);
   this.request_sender = request_sender;
@@ -344,7 +349,7 @@ AckClientTransaction.prototype.send = function() {
 };
 
 AckClientTransaction.prototype.onTransportError = function() {
-  console.log(LOG_PREFIX +'transport error occurred, for an ACK client transaction ' + this.id);
+  this.logger.log('transport error occurred, for an ACK client transaction ' + this.id);
   this.request_sender.onTransportError();
 };
 
@@ -357,6 +362,8 @@ AckClientTransaction.prototype.onTransportError = function() {
 */
 var NonInviteServerTransaction = function(request, ua) {
   var events = ['stateChanged'];
+
+  this.logger = ua.createLogger('jssip.transaction');
 
   this.type = C.NON_INVITE_SERVER;
   this.id = request.via_branch;
@@ -380,7 +387,7 @@ NonInviteServerTransaction.prototype.stateChanged = function(state) {
 };
 
 NonInviteServerTransaction.prototype.timer_J = function() {
-  console.log(LOG_PREFIX +'Timer J expired for non-INVITE server transaction ' + this.id);
+  this.logger.log('Timer J expired for non-INVITE server transaction ' + this.id);
   this.stateChanged(C.STATUS_TERMINATED);
   this.ua.destroyTransaction(this);
 };
@@ -389,7 +396,7 @@ NonInviteServerTransaction.prototype.onTransportError = function() {
   if (!this.transportError) {
     this.transportError = true;
 
-    console.log(LOG_PREFIX +'transport error occurred, deleting non-INVITE server transaction ' + this.id);
+    this.logger.log('transport error occurred, deleting non-INVITE server transaction ' + this.id);
 
     window.clearTimeout(this.J);
     this.ua.destroyTransaction(this);
@@ -457,6 +464,8 @@ NonInviteServerTransaction.prototype.receiveResponse = function(status_code, res
 var InviteServerTransaction = function(request, ua) {
   var events = ['stateChanged'];
 
+  this.logger = ua.createLogger('jssip.transaction');
+
   this.type = C.INVITE_SERVER;
   this.id = request.via_branch;
   this.request = request;
@@ -483,10 +492,10 @@ InviteServerTransaction.prototype.stateChanged = function(state) {
 };
 
 InviteServerTransaction.prototype.timer_H = function() {
-  console.log(LOG_PREFIX +'Timer H expired for INVITE server transaction ' + this.id);
+  this.logger.log('Timer H expired for INVITE server transaction ' + this.id);
 
   if(this.state === C.STATUS_COMPLETED) {
-    console.warn(LOG_PREFIX +'transactions', 'ACK for INVITE server transaction was never received, call will be terminated');
+    this.logger.warn('transactions', 'ACK for INVITE server transaction was never received, call will be terminated');
     this.stateChanged(C.STATUS_TERMINATED);
   }
 
@@ -500,7 +509,7 @@ InviteServerTransaction.prototype.timer_I = function() {
 
 // RFC 6026 7.1
 InviteServerTransaction.prototype.timer_L = function() {
-  console.log(LOG_PREFIX +'Timer L expired for INVITE server transaction ' + this.id);
+  this.logger.log('Timer L expired for INVITE server transaction ' + this.id);
 
   if(this.state === C.STATUS_ACCEPTED) {
     this.stateChanged(C.STATUS_TERMINATED);
@@ -512,7 +521,7 @@ InviteServerTransaction.prototype.onTransportError = function() {
   if (!this.transportError) {
     this.transportError = true;
 
-    console.log(LOG_PREFIX +'transport error occurred, deleting INVITE server transaction ' + this.id);
+    this.logger.log('transport error occurred, deleting INVITE server transaction ' + this.id);
 
     window.clearTimeout(this.reliableProvisionalTimer);
     window.clearTimeout(this.L);

--- a/src/Transport.js
+++ b/src/Transport.js
@@ -10,7 +10,6 @@
  */
 (function(JsSIP) {
 var Transport,
-  LOG_PREFIX = JsSIP.name +' | '+ 'TRANSPORT' +' | ',
   C = {
     // Transport status codes
     STATUS_READY:        0,
@@ -19,6 +18,8 @@ var Transport,
   };
 
 Transport = function(ua, server) {
+
+  this.logger = ua.createLogger('jssip.transport');
   this.ua = ua;
   this.ws = null;
   this.server = server;
@@ -45,12 +46,12 @@ Transport.prototype = {
 
     if(this.ws && this.ws.readyState === WebSocket.OPEN) {
       if (this.ua.configuration.trace_sip === true) {
-        console.log(LOG_PREFIX +'sending WebSocket message:\n\n' + message + '\n');
+        this.logger.log('sending WebSocket message:\n\n' + message + '\n');
       }
       this.ws.send(message);
       return true;
     } else {
-      console.warn(LOG_PREFIX +'unable to send message, WebSocket is not open');
+      this.logger.warn('unable to send message, WebSocket is not open');
       return false;
     }
   },
@@ -61,7 +62,7 @@ Transport.prototype = {
   disconnect: function() {
     if(this.ws) {
       this.closed = true;
-      console.log(LOG_PREFIX +'closing WebSocket ' + this.server.ws_uri);
+      this.logger.log('closing WebSocket ' + this.server.ws_uri);
       this.ws.close();
     }
   },
@@ -73,7 +74,7 @@ Transport.prototype = {
     var transport = this;
 
     if(this.ws && (this.ws.readyState === WebSocket.OPEN || this.ws.readyState === WebSocket.CONNECTING)) {
-      console.log(LOG_PREFIX +'WebSocket ' + this.server.ws_uri + ' is already connected');
+      this.logger.log('WebSocket ' + this.server.ws_uri + ' is already connected');
       return false;
     }
 
@@ -81,12 +82,12 @@ Transport.prototype = {
       this.ws.close();
     }
 
-    console.log(LOG_PREFIX +'connecting to WebSocket ' + this.server.ws_uri);
+    this.logger.log('connecting to WebSocket ' + this.server.ws_uri);
 
     try {
       this.ws = new WebSocket(this.server.ws_uri, 'sip');
     } catch(e) {
-      console.warn(LOG_PREFIX +'error connecting to WebSocket ' + this.server.ws_uri + ': ' + e);
+      this.logger.warn('error connecting to WebSocket ' + this.server.ws_uri + ': ' + e);
     }
 
     this.ws.binaryType = 'arraybuffer';
@@ -117,7 +118,7 @@ Transport.prototype = {
   onOpen: function() {
     this.connected = true;
 
-    console.log(LOG_PREFIX +'WebSocket ' + this.server.ws_uri + ' connected');
+    this.logger.log('WebSocket ' + this.server.ws_uri + ' connected');
     // Clear reconnectTimer since we are not disconnected
     window.clearTimeout(this.reconnectTimer);
     // Disable closed
@@ -136,10 +137,10 @@ Transport.prototype = {
     this.connected = false;
     this.lastTransportError.code = e.code;
     this.lastTransportError.reason = e.reason;
-    console.warn(LOG_PREFIX +'WebSocket disconnected (code: ' + e.code + (e.reason? '| reason: ' + e.reason : '') +')');
+    this.logger.warn('WebSocket disconnected (code: ' + e.code + (e.reason? '| reason: ' + e.reason : '') +')');
 
     if(e.wasClean === false) {
-      console.warn(LOG_PREFIX +'WebSocket abrupt disconnection');
+      this.logger.warn('WebSocket abrupt disconnection');
     }
     // Transport was connected
     if(connected_before === true) {
@@ -174,7 +175,7 @@ Transport.prototype = {
     // CRLF Keep Alive response from server. Ignore it.
     if(data === '\r\n') {
       if (this.ua.configuration.trace_sip === true) {
-        console.log(LOG_PREFIX +'received WebSocket message with CRLF Keep Alive response');
+        this.logger.log('received WebSocket message with CRLF Keep Alive response');
       }
       return;
     }
@@ -184,23 +185,23 @@ Transport.prototype = {
       try {
         data = String.fromCharCode.apply(null, new Uint8Array(data));
       } catch(evt) {
-        console.warn(LOG_PREFIX +'received WebSocket binary message failed to be converted into string, message discarded');
+        this.logger.warn('received WebSocket binary message failed to be converted into string, message discarded');
         return;
       }
 
       if (this.ua.configuration.trace_sip === true) {
-        console.log(LOG_PREFIX +'received WebSocket binary message:\n\n' + data + '\n');
+        this.logger.log('received WebSocket binary message:\n\n' + data + '\n');
       }
     }
 
     // WebSocket text message.
     else {
       if (this.ua.configuration.trace_sip === true) {
-        console.log(LOG_PREFIX +'received WebSocket text message:\n\n' + data + '\n');
+        this.logger.log('received WebSocket text message:\n\n' + data + '\n');
       }
     }
 
-    message = JsSIP.Parser.parseMessage(data);
+    message = JsSIP.Parser.parseMessage(data, this.logger);
 
     if(this.ua.status === JsSIP.UA.C.STATUS_USER_CLOSED && message instanceof JsSIP.IncomingRequest) {
       return;
@@ -242,7 +243,7 @@ Transport.prototype = {
   * @param {event} e
   */
   onError: function(e) {
-    console.warn(LOG_PREFIX +'WebSocket connection error: ' + e);
+    this.logger.warn('WebSocket connection error: ' + e);
   },
 
   /**
@@ -255,10 +256,10 @@ Transport.prototype = {
     this.reconnection_attempts += 1;
 
     if(this.reconnection_attempts > this.ua.configuration.ws_server_max_reconnection) {
-      console.warn(LOG_PREFIX +'maximum reconnection attempts for WebSocket ' + this.server.ws_uri);
+      this.logger.warn('maximum reconnection attempts for WebSocket ' + this.server.ws_uri);
       this.ua.onTransportError(this);
     } else {
-      console.log(LOG_PREFIX +'trying to reconnect to WebSocket ' + this.server.ws_uri + ' (reconnection attempt ' + this.reconnection_attempts + ')');
+      this.logger.log('trying to reconnect to WebSocket ' + this.server.ws_uri + ' (reconnection attempt ' + this.reconnection_attempts + ')');
 
       this.reconnectTimer = window.setTimeout(function() {
         transport.connect();}, this.ua.configuration.ws_server_reconnection_timeout * 1000);


### PR DESCRIPTION
Hi! I'd like to propose this change for inclusion in JsSIP.

It introduces a new configuration option `logger_factory`.  This option can be set to a function receiving one argument, `category`, and returning an object with (at least) functions `debug`, `log`, `warn`, and `error`. The semantics of these functions are identical to the corresponding functions in the browser `console` object.

If the `logger_factory` option isn't specified the default is to log using the `console` object, with each log message prefixed by the log category in square brackets.  This means that logging will work as before, except that the prefix is formatted differently.

This change makes logging calls more DRY by obviating the need to manually prefix log messages with `LOG_PREFIX`. More importantly, it enables use of third-party logging frameworks such as log4javascript, which in turn is useful for, say, remote logging.

This is obviously a pervasive change. All 253 tests still pass and a smoke test (incl. WebRTC session) works. However, since the tests don't have full coverage I can't be certain it doesn't break anything. If you're willing to accept this patch, please review and test it carefully. I'm happy to improve on it in case you find any remaining issues.
