### PR TITLE
Fix RTCSession.get(Local|Remote)Streams in FF 22

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -370,13 +370,17 @@ RTCSession.prototype.sendDTMF = function(tones, options) {
 RTCSession.prototype.getLocalStreams = function() {
   return this.rtcMediaHandler &&
     this.rtcMediaHandler.peerConnection &&
-    this.rtcMediaHandler.peerConnection.getLocalStreams() || [];
+    (this.rtcMediaHandler.peerConnection.getLocalStreams &&
+     this.rtcMediaHandler.peerConnection.getLocalStreams()) ||
+    (this.rtcMediaHandler.peerConnection.localStreams) || [];
 };
 
 RTCSession.prototype.getRemoteStreams = function() {
   return this.rtcMediaHandler &&
     this.rtcMediaHandler.peerConnection &&
-    this.rtcMediaHandler.peerConnection.getRemoteStreams() || [];
+    (this.rtcMediaHandler.peerConnection.getRemoteStreams &&
+     this.rtcMediaHandler.peerConnection.getRemoteStreams()) ||
+    (this.rtcMediaHandler.peerConnection.remoteStreams) || [];
 };
 
 


### PR DESCRIPTION
In FF 22 localStream and remoteStreams on mozRTCPeerConnection are properties and the code to add methods getters on mozRTCPeerConnection for them doesn't work. It seems the object is not a 100% Javascript object, as it lacks prototype and attempts to add it don't work, either.

This patch workarounds this issue by checking the properties in RTCSession - the only place they are used. After this fix we managed to get a working call in FF 22.
