### PR TITLE
setLocalDescription fix

### DIFF
--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -78,7 +78,7 @@ RTCMediaHandler.prototype = {
   setLocalDescription: function(sessionDescription, onFailure) {
     this.peerConnection.setLocalDescription(
       sessionDescription,
-      null,
+      function(){},
       function(e) {
         console.error(LOG_PREFIX +'unable to set local description');
         console.error(e);


### PR DESCRIPTION
According to http://www.w3.org/TR/webrtc/#dom-peerconnection-setlocaldescription.
successCallback of setLocalDescription is not nullable.
This patch also fix problem in firefox 24.
