### PR TITLE
Fix "Object #<Object> has no method 'onIceCompleted'" when caller cancel the call.

### DIFF
--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -137,7 +137,7 @@ RTCMediaHandler.prototype = {
     this.peerConnection.onicecandidate = function(e) {
       if (e.candidate) {
         console.log(LOG_PREFIX +'ICE candidate received: '+ e.candidate.candidate);
-      } else {
+      } else if (self.onIceCompleted !== undefined) {
         self.onIceCompleted();
       }
     };


### PR DESCRIPTION
Fixes #86 "Object #<Object> has no method 'onIceCompleted'" when caller cancel the call. 

Does a simple check to see that self.onIceCompleted is valid before trying to call onIceCompleted.
