### PR TITLE
Proposed INVITE w/o SDP UAC behavior

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -44,6 +44,7 @@ RTCSession = function(ua) {
   this.dialog = null;
   this.earlyDialogs = {};
   this.rtcMediaHandler = null;
+  this.mediaStream = null;
 
   // Session Timers
   this.timers = {
@@ -515,8 +516,8 @@ RTCSession.prototype.connect = function(target, options) {
     eventHandlers = options.eventHandlers || {},
     extraHeaders = options.extraHeaders || [],
     mediaConstraints = options.mediaConstraints || {audio: true, video: true},
-    RTCConstraints = options.RTCConstraints || {};
-
+    RTCConstraints = options.RTCConstraints || {},
+    inviteWithoutSdp = options.inviteWithoutSdp || false;
   if (target === undefined) {
     throw new TypeError('Not enough arguments');
   }
@@ -564,10 +565,11 @@ RTCSession.prototype.connect = function(target, options) {
     extraHeaders.push('P-Preferred-Identity: '+ this.ua.configuration.uri.toString());
     extraHeaders.push('Privacy: id');
   }
-
   extraHeaders.push('Contact: '+ this.contact);
   extraHeaders.push('Allow: '+ JsSIP.Utils.getAllowedMethods(this.ua));
-  extraHeaders.push('Content-Type: application/sdp');
+  if (!inviteWithoutSdp) {
+    extraHeaders.push('Content-Type: application/sdp');
+  }
 
   this.request = new JsSIP.OutgoingRequest(JsSIP.C.INVITE, target, this.ua, requestParams, extraHeaders);
 
@@ -575,13 +577,43 @@ RTCSession.prototype.connect = function(target, options) {
 
   //Save the session into the ua sessions collection.
   this.ua.sessions[this.id] = this;
-
   this.newRTCSession('local', this.request);
 
   if (invalidTarget) {
     this.failed('local', null, JsSIP.C.causes.INVALID_TARGET);
   } else if (!JsSIP.WebRTC.isSupported) {
     this.failed('local', null, JsSIP.C.causes.WEBRTC_NOT_SUPPORTED);
+  } else if (inviteWithoutSdp) {
+    var self = this;
+    var streamAdditionSucceeded = function() {
+      //just send an invite with no sdp...
+      var request_sender = new JsSIP.RequestSender(self, self.ua);
+      request_sender.send();
+    };
+    var streamAdditionFailed = function () {
+      if (self.status === C.STATUS_TERMINATED) {
+        return;
+      }
+      self.failed('local', null, JsSIP.C.causes.WEBRTC_ERROR);
+    };
+    var userMediaSucceeded = function(stream) {
+      self.rtcMediaHandler.addStream(
+        stream,
+        streamAdditionSucceeded,
+        streamAdditionFailed
+      );
+    };
+    var userMediaFailed = function() {
+      if (self.status === C.STATUS_TERMINATED) {
+        return;
+      }
+      self.failed('local', null, JsSIP.C.causes.USER_DENIED_MEDIA_ACCESS);
+    };
+    this.rtcMediaHandler.getUserMedia(
+      userMediaSucceeded,
+      userMediaFailed,
+      mediaConstraints
+    );
   } else {
     this.sendInitialRequest(mediaConstraints);
   }
@@ -750,7 +782,7 @@ RTCSession.prototype.receiveRequest = function(request) {
  * Initial Request Sender
  * @private
  */
-RTCSession.prototype.sendInitialRequest = function(constraints) {
+RTCSession.prototype.sendInitialRequest = function(mediaConstraints) {
   var
   self = this,
  request_sender = new JsSIP.RequestSender(self, this.ua),
@@ -813,7 +845,7 @@ RTCSession.prototype.sendInitialRequest = function(constraints) {
  this.rtcMediaHandler.getUserMedia(
    userMediaSucceeded,
    userMediaFailed,
-   constraints
+   mediaConstraints
  );
 };
 
@@ -826,7 +858,9 @@ RTCSession.prototype.receiveResponse = function(response) {
     session = this;
 
   if(this.status !== C.STATUS_INVITE_SENT && this.status !== C.STATUS_1XX_RECEIVED) {
-    return;
+    if (response.status_code!==200) {
+      return;
+    }
   }
 
   // Proceed to cancellation if the user requested.
@@ -876,35 +910,76 @@ RTCSession.prototype.receiveResponse = function(response) {
         break;
       }
 
-      this.rtcMediaHandler.onMessage(
-        'answer',
-        response.body,
-        /*
-         * onSuccess
-         * SDP Answer fits with Offer. Media will start
-         */
-        function() {
-          session.status = C.STATUS_CONFIRMED;
-          session.sendACK();
-          session.started('remote', response);
-        },
-        /*
-         * onFailure
-         * SDP Answer does not fit the Offer. Accept the call and Terminate.
-         */
-        function(e) {
-          console.warn(e);
-          session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
-          session.failed('remote', response, JsSIP.C.causes.BAD_MEDIA_DESCRIPTION);
-        }
-      );
+      // This is an invite without sdp
+      if (!this.request.body) {
+        this.rtcMediaHandler.onMessage(
+          'offer',
+          response.body,
+          /*
+           * onSuccess
+           * SDP Offer is valid. Fire UA newRTCSession
+           */
+          function() {
+            var offerCreationSucceeded = function (offer) {
+              if(session.isCanceled || session.status === C.STATUS_TERMINATED) {
+                return;
+              }
+              session.status = C.STATUS_CONFIRMED;
+              session.sendRequest(JsSIP.C.ACK,{
+                body:offer,
+                extraHeaders:["Content-Type: application/sdp"]
+              });
+              session.started('remote', response);
+            };
+            var offerCreationFailed = function () {
+              //do something here
+              console.log("there was a problem");
+            };
+            session.rtcMediaHandler.createAnswer(
+              offerCreationSucceeded,
+              offerCreationFailed
+            );
+          },
+          /*
+           * onFailure
+           * Bad media description
+           */
+          function(e) {
+            session.logger.warn('invalid SDP');
+            session.logger.warn(e);
+            response.reply(488);
+          }
+        );
+      } else {
+        this.rtcMediaHandler.onMessage(
+          'answer',
+          response.body,
+          /*
+           * onSuccess
+           * SDP Answer fits with Offer. Media will start
+           */
+          function() {
+            session.status = C.STATUS_CONFIRMED;
+            session.sendACK();
+            session.started('remote', response);
+          },
+          /*
+           * onFailure
+           * SDP Answer does not fit the Offer. Accept the call and Terminate.
+           */
+          function(e) {
+            console.warn(e);
+            session.acceptAndTerminate(response, 488, 'Not Acceptable Here');
+            session.failed('remote', response, JsSIP.C.causes.BAD_MEDIA_DESCRIPTION);
+          }
+        );
+      }
       break;
     default:
       cause = JsSIP.Utils.sipErrorCause(response.status_code);
       this.failed('remote', response, cause);
   }
 };
-
 
 /**
 * @private

--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -10,13 +10,13 @@
 (function(JsSIP){
 
 var RTCMediaHandler = function(session, constraints) {
-  constraints = constraints || {};
+  this.constraints = constraints || {};
 
   this.session = session;
   this.localMedia = null;
   this.peerConnection = null;
 
-  this.init(constraints);
+  this.init();
 };
 
 RTCMediaHandler.prototype = {
@@ -71,7 +71,8 @@ RTCMediaHandler.prototype = {
         console.error(LOG_PREFIX +'unable to create answer');
         console.error(e);
         onFailure();
-      }
+      },
+      this.constraints
     );
   },
 
@@ -104,7 +105,7 @@ RTCMediaHandler.prototype = {
   * peerConnection creation.
   * @param {Function} onSuccess Fired when there are no more ICE candidates
   */
-  init: function(constraints) {
+  init: function() {
     var idx, length, server, scheme, url,
       self = this,
       servers = [],
@@ -127,7 +128,7 @@ RTCMediaHandler.prototype = {
       });
     }
 
-    this.peerConnection = new JsSIP.WebRTC.RTCPeerConnection({'iceServers': servers}, constraints);
+    this.peerConnection = new JsSIP.WebRTC.RTCPeerConnection({'iceServers': servers}, this.constraints);
 
     this.peerConnection.onaddstream = function(e) {
       console.log(LOG_PREFIX +'stream added: '+ e.stream.id);
@@ -177,12 +178,12 @@ RTCMediaHandler.prototype = {
   * @param {Function} onSuccess
   * @param {Function} onFailure
   */
-  getUserMedia: function(onSuccess, onFailure, constraints) {
+  getUserMedia: function(onSuccess, onFailure, mediaConstraints) {
     var self = this;
 
     console.log(LOG_PREFIX + 'requesting access to local media');
 
-    JsSIP.WebRTC.getUserMedia(constraints,
+    JsSIP.WebRTC.getUserMedia(mediaConstraints,
       function(stream) {
         console.log(LOG_PREFIX + 'got local media stream');
         self.localMedia = stream;


### PR DESCRIPTION
We've been working on this as a custom feature, so I thought I'd push it back to the community for input.  We've implemented INVITE w/o SDP as per RFC3261.

Implementation notes:

This is mostly built on the existing RTCSession structure.  The media stream is still requested before inviting, and the stream is carried around on the session until it is needed.  The application probably wants to add an `OfferToReceiveVideo: false` constraint when making audio-only calls.

RTCMediaHandler was modified to store RTCConstraints beyond initial creation, as we found browsers mostly didn't respect the setting until the createAnswer() call, and the session didn't want to carry it around for that long.

Thoughts?
