### PR TITLE
Properly handle unknown media-types in INFO

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -739,6 +739,8 @@ RTCSession.prototype.receiveRequest = function(request) {
           contentType = request.getHeader('content-type');
           if (contentType && (contentType.match(/^application\/dtmf-relay/i))) {
             new DTMF(this).init_incoming(request);
+          } else {
+            request.reply(415,null,['Accept: application/dtmf-relay']);
           }
         }
     }


### PR DESCRIPTION
Send a 415 Unsupported Media Type response if an INFO message contains an unknown media-type.

I noticed this during interop with FreeSwitch. FreeSwitch sends an INFO message:

```
INFO sip:trnrph3g@8ovnkn8jm6fs.invalid;transport=ws;ob SIP/2.0
Via: SIP/2.0/WS 127.0.0.1:8060;branch=z9hG4bKe5S382rp2N4ta
Max-Forwards: 70
From: <sip:conf@127.0.0.1;transport=ws>;tag=jFvKFSK4pHQ2F
To: <sip:alice@example.com>;tag=rk0p55l0lt
Call-ID: 9tkif8fahbk1guksim84
CSeq: 56066404 INFO
Contact: <sip:conf@127.0.0.1:5060;transport=udp>
User-Agent: websocket server
Allow: INVITE, ACK, BYE, CANCEL, OPTIONS, MESSAGE, INFO, UPDATE, REGISTER, NOTIFY
Supported: timer, precondition, path, replaces
Content-Type: application/media_control+xml
Content-Length: 175

<?xml version="1.0" encoding="utf-8" ?>
<media_control>
<vc_primitive>
<to_encoder>
<picture_fast_update>
</picture_fast_update>
</to_encoder>
</vc_primitive>
</media_control>
```

but the code in JsSIP is not set to reply to it -- FreeSwitch keeps sending the INFO message.

I'm not sure what the interaction with WebRTC should be -- a 415 response with `Accept: application/dtmf-relay` looks like the appropriate way to handle this for now. 
