### PR TITLE
Add missing constant BYE

### DIFF
--- a/src/Constants.js
+++ b/src/Constants.js
@@ -34,6 +34,7 @@ JsSIP.C= {
     DIALOG_ERROR:             'Dialog Error',
 
     // Session error causes
+    BYE:                      'Terminated',
     WEBRTC_NOT_SUPPORTED:     'WebRTC Not Supported',
     WEBRTC_ERROR:             'WebRTC Error',
     CANCELED:                 'Canceled',


### PR DESCRIPTION
The "ended" event's event.data.cause was undefined because the `JsSIP.C.causes.BYE` constant was not defined. According to the documentation (http://jssip.net/documentation/devel/api/causes/), BYE is "Terminated", so I've added the missing BYE constant with this value.
