### PR TITLE
Type checking for DTMF fixed, tone 0 could not be sent

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -320,13 +320,16 @@ RTCSession.prototype.sendDTMF = function(tones, options) {
     throw new JsSIP.Exceptions.InvalidStateError(this.status);
   }
 
-  // Check tones
-  if (!tones || (typeof tones !== 'string' && typeof tones !== 'number') || !tones.toString().match(/^[0-9A-D#*,]+$/i)) {
-    throw new TypeError('Invalid tones: '+ tones);
+  // Convert to string
+  if(typeof tones === 'number') {
+    tones = tones.toString();
   }
 
-  tones = tones.toString();
-
+  // Check tones
+  if (!tones || typeof tones !== 'string' || !tones.match(/^[0-9A-D#*,]+$/i)) {
+    throw new TypeError('Invalid tones: '+ tones);
+  }
+ 
   // Check duration
   if (duration && !JsSIP.Utils.isDecimal(duration)) {
     throw new TypeError('Invalid tone duration: '+ duration);


### PR DESCRIPTION
Because of the rigid type checking the DTMF tone for 0 could not be sent. Would be good to have this fixed for the upcoming new version.

OT: I shouldn't criticize this project which is really great work, but in my opinion the very careful type checking is causing problems sometimes (this also happened with the STUN server checks). Passing an empty string, array or a zero is not always unintentional. Relaxing the type checking generally would help avoiding unnecessary problems.
