### PR TITLE
Actually pass RTC constraints to RTCMediaHandler

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -847,7 +847,7 @@ RTCSession.prototype.init_incoming = function(request) {
 
   //Initialize Media Session
   this.rtcMediaHandler = new RTCMediaHandler(this, {
-    RTCConstraints: {"optional": [{'DtlsSrtpKeyAgreement': 'true'}]}
+    constraints: {"optional": [{'DtlsSrtpKeyAgreement': 'true'}]}
     });
     
   this.rtcMediaHandler.onMessage(
@@ -990,7 +990,7 @@ RTCSession.prototype.connect = function(target, options) {
   this.logger = this.ua.getLogger('jssip.rtcsession', this.id);
 
   this.rtcMediaHandler = new RTCMediaHandler(this, {
-    RTCConstraints: RTCConstraints,
+    constraints: RTCConstraints,
     stun_servers: stun_servers,
     turn_servers: turn_servers
     });


### PR DESCRIPTION
Currently JsSIP.UA.call's RTCConstraints option is being ignored.

The reason is that the constraints are incorrectly passed to RTCMediaHandler: they are passed as an option called "RTCConstraints", which is ignored by RTCMediaHandler, as it expects "constraints".
