### PR TITLE
Media events for success or failure of getUserMedia

### DIFF
--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -233,14 +233,19 @@ RTCMediaHandler.prototype = {
       function(stream) {
         self.logger.log('got local media stream');
         self.localMedia = stream;
+        self.session.ua.emit('mediaGranted',self.session.ua,constraints);
         onSuccess(stream);
       },
       function(e) {
         self.logger.error('unable to get user media');
         self.logger.error(e);
+        self.session.ua.emit('mediaDenied',self.session.ua,e);
         onFailure();
       }
     );
+
+    this.session.ua.emit('mediaRequested',this.session.ua,constraints);
+
   },
 
   /**

--- a/src/UA.js
+++ b/src/UA.js
@@ -56,7 +56,10 @@ UA = function(configuration) {
     'unregistered',
     'registrationFailed',
     'newRTCSession',
-    'newMessage'
+    'newMessage',
+    'mediaRequested',
+    'mediaDenied',
+    'mediaGranted'
   ];
 
   // Set Accepted Body Types


### PR DESCRIPTION
Hi,

I noticed it's hard to provide good user feedback when requesting media access. There is currently no way of knowing if something went wrong during media retrieval. For this I've added three events to monitor media access:
- mediaRequested: fires straight after getUserMedia has been called (can instruct user of the need to approve)
- mediaGranted: media with the constraints requested was successful (user may be informed)
- mediaDenied: media access was denied either by user action or lacking capability (error message can be displayed)

This kind of events are really necessary to build robust and user friendly applications with JsSIP so please consider merging this commit into the next release branch. Feel free to tweak it to be consistent with the application in general.
