### PR TITLE
fix createAnswer / createOffer when ICE state is 'completed'

### DIFF
--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -30,7 +30,7 @@ RTCMediaHandler.prototype = {
     var self = this;
 
     function onSetLocalDescriptionSuccess() {
-      if (self.peerConnection.iceGatheringState === 'complete' && self.peerConnection.iceConnectionState === 'connected') {
+      if (self.peerConnection.iceGatheringState === 'complete' && (self.peerConnection.iceConnectionState === 'connected' || self.peerConnection.iceConnectionState === 'completed')) {
         self.ready = true;
         onSuccess(self.peerConnection.localDescription.sdp);
       } else {
@@ -69,7 +69,7 @@ RTCMediaHandler.prototype = {
     var self = this;
 
     function onSetLocalDescriptionSuccess() {
-      if (self.peerConnection.iceGatheringState === 'complete' && self.peerConnection.iceConnectionState === 'connected') {
+      if (self.peerConnection.iceGatheringState === 'complete' && (self.peerConnection.iceConnectionState === 'connected' || self.peerConnection.iceConnectionState === 'completed')) {
         self.ready = true;
         onSuccess(self.peerConnection.localDescription.sdp);
       } else {


### PR DESCRIPTION
RTCMediaHandler's createAnswer and createOffer methods never invoke the
success callback if the ICE state is 'completed'. This happens because the
onSetLocalDescriptionSuccess callbacks check whether the ICE state is
'connected' instead of 'connected' or 'completed'. As a consequence of this,
hold and unhold no longer works once ICE reaches the 'completed' state.

This change fixes the ICE state test to allow both 'connected' and 'completed'.
