### PR TITLE
Update browserify recommended to last version (semicolon bug fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-contrib-jshint": "~0.3.0",
     "grunt-contrib-qunit": "~0.2.0",
-    "grunt-browserify": "~1.3.0",
+    "grunt-browserify": ">=1.3.0",
     "pegjs": "0.7.0",
     "node-minify": "~0.7.2",
     "sdp-transform": "~0.5.3"


### PR DESCRIPTION
Browserify update fixes missing trailing semicolon after building resulting library file. Thus it can be merged with some other wrapper files. ">=" takes npm to install latest version. Do not know if it must be specific or not (in my projects all deps with ">=").
