### PR TITLE
connectionFailed event and connection_autorecovery flag

### DIFF
--- a/src/Transport.js
+++ b/src/Transport.js
@@ -250,7 +250,7 @@ Transport.prototype = {
 
     this.reconnection_attempts += 1;
 
-    if(this.reconnection_attempts > this.ua.configuration.ws_server_max_reconnection) {
+    if(this.reconnection_attempts > this.ua.configuration.ws_server_max_reconnection || !this.ua.configuration.connection_autorecovery) {
       this.logger.warn('maximum reconnection attempts for WebSocket ' + this.server.ws_uri);
       this.ua.onTransportError(this);
     } else {


### PR DESCRIPTION
Event `connectionFailed` to separate connection failure from normal disconnection process and possibility to disable auto connection recovery with `connection_autorecovery` flag. With this any wrapper to JsSIP can control connection recovery itself syncing it with other modules.

If you prefer not to have `connectionFailed` event I can separate this feature..
