### PR TITLE
onSuccess never called, JsSIP stalled

### DIFF
--- a/src/RTCSession/RTCMediaHandler.js
+++ b/src/RTCSession/RTCMediaHandler.js
@@ -26,7 +26,7 @@ RTCMediaHandler.prototype = {
     var self = this;
 
     function onSetLocalDescriptionSuccess() {
-      if (self.peerConnection.iceGatheringState === 'complete' && (self.peerConnection.iceConnectionState === 'connected' || self.peerConnection.iceConnectionState === 'completed')) {
+      if (self.peerConnection.iceGatheringState === 'complete') {
         self.ready = true;
         onSuccess(self.peerConnection.localDescription.sdp);
       } else {
@@ -65,7 +65,7 @@ RTCMediaHandler.prototype = {
     var self = this;
 
     function onSetLocalDescriptionSuccess() {
-      if (self.peerConnection.iceGatheringState === 'complete' && (self.peerConnection.iceConnectionState === 'connected' || self.peerConnection.iceConnectionState === 'completed')) {
+      if (self.peerConnection.iceGatheringState === 'complete') {
         self.ready = true;
         onSuccess(self.peerConnection.localDescription.sdp);
       } else {


### PR DESCRIPTION
JsSIP stopped working in FF33. We are using WebRTC without STUN servers and the problem was caused by the different way ICE candidates are trickling in FF and Chrome.

In Chrome this happens:
1. An offer SDP is created
2. iceGatheringState is gathering
3. The local description is set and onSetLocalDescriptionSuccess is called
3. ICE candidates come trickling in
4. iceGatheringState change to complete with the last candidate being null

In JsSIP you rely on the onIceCompleted method of the RTCMediaHandler to be called after step 4 when the onicecandidate event happens. This works fine in Chrome.

In Firefox this happens:
1. An offer SDP is created
2. onicecandidate is fired with a null candidate because all candidates are already in the SDP (onIceCompleted not defined and not called)
3. iceGatheringState is complete since all candidates are in the SDP
4. The local description is set and onSetLocalDescriptionSuccess is called

The problem here is that JsSIP onicecandidate is fired before onIceCompleted has been defined (because the local description has not been set). Also the preventive check if all candidates have already been created and the iceGatheringState is complete fails because iceConnectionState is supposed to be connected.

In the code onSuccess is never called and JsSIP stalls. By removing the requirement that iceConnectionState is connected (not sure why this requirement is there, during this phase you can't expect connection to be ready, no remote SDP has been set, as far as I can see), it worked. At this stage the iceConnectionState is new which seems to be reasonable.

Also this is for the SDP offer process, I would expect similar problems for the SDP answer process (when the iceConnectionState is checking if I don't remember wrong).

Suggested solution in the pull request, solved the issue for us.
