### PR TITLE
Fix 'this' references

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -1634,7 +1634,7 @@ RTCSession.prototype.receiveInviteResponse = function(response) {
         */
         function(e) {
           session.logger.warn(e);
-          this.earlyDialogs[response.call_id + response.from_tag + response.to_tag].terminate();
+          session.earlyDialogs[response.call_id + response.from_tag + response.to_tag].terminate();
         }
       );
       break;

--- a/src/UA.js
+++ b/src/UA.js
@@ -794,7 +794,7 @@ UA.prototype.loadConfig = function(configuration) {
       throw new JsSIP.Exceptions.ConfigurationError(parameter);
     } else {
       value = configuration[parameter];
-      checked_value = UA.configuration_check.mandatory[parameter](value);
+      checked_value = UA.configuration_check.mandatory[parameter].call(this, value);
       if (checked_value !== undefined) {
         settings[parameter] = checked_value;
       } else {
@@ -815,7 +815,7 @@ UA.prototype.loadConfig = function(configuration) {
         continue;
       }
 
-      checked_value = UA.configuration_check.optional[parameter](value);
+      checked_value = UA.configuration_check.optional[parameter].call(this, value);
       if (checked_value !== undefined) {
         settings[parameter] = checked_value;
       } else {


### PR DESCRIPTION
Changed `this` to `session` in `RTCSession.prototype.receiveInviteResponse` and
set `this` to the `UA` instance in the configuration checking, to prevent `this.logger.error(...)` in `UA.configuration_check.mandatory.ws_servers` from failing.
