### PR TITLE
Document backwards-incompatible changes in 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 CHANGELOG
 =========
+Version 0.6.0 (to be released)
+--------------------------------------
+* [(6583659)](https://github.com/versatica/JsSIP/commit/6583659) Replaced event module with EventEmitter. `event.sender` is now `this` and `event.data` is `event`.
+* [(6205ba1)](https://github.com/versatica/JsSIP/commit/6205ba1) Removed `log` and `trace_sip` configuration options. Logging is now handled by the [debug module](https://github.com/visionmedia/debug).
 
 Version 0.5.0 (released in 2014-11-03)
 --------------------------------------


### PR DESCRIPTION
We just upgraded jssip in our application (to master), but the application broke down unexpectedly. After some debugging, I discovered that there were some undocumented backwards-incompatible changes. I've added a few entries to CHANGELOG.

Note that logging/debugging is completely broken. I'll create a separate ticket for that.
