### PR TITLE
Don't ask for media in answers if audio and video constraints are not set

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -540,6 +540,9 @@ RTCSession.prototype.answer = function(options) {
 
   if (mediaStream) {
     userMediaSucceeded(mediaStream);
+  } else if (!mediaConstraints.audio && !mediaConstraints.video) {
+    // Receive-only mode.
+    userMediaSucceeded(null);
   } else {
     self.localMediaStreamLocallyGenerated = true;
     rtcninja.getUserMedia(
@@ -554,7 +557,9 @@ RTCSession.prototype.answer = function(options) {
     if (self.status === C.STATUS_TERMINATED) { return; }
 
     self.localMediaStream = stream;
-    self.connection.addStream(stream);
+    if (stream) {
+      self.connection.addStream(stream);
+    }
 
     if (! self.late_sdp) {
       self.connection.setRemoteDescription(


### PR DESCRIPTION
0.6.8 added a similar feature, but only for outgoing calls.