### PR TITLE
Incorrect logic in uri scheme parsing

### DIFF
--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -3059,18 +3059,7 @@ module.exports = (function(){
         var result0;
         var pos0;
         
-        if (input.substr(pos, 3).toLowerCase() === "sip") {
-          result0 = input.substr(pos, 3);
-          pos += 3;
-        } else {
-          result0 = null;
-          if (reportFailures === 0) {
-            matchFailed("\"sip\"");
-          }
-        }
-        if (result0 === null) {
-          pos0 = pos;
-          if (input.substr(pos, 4).toLowerCase() === "sips") {
+         (input.substr(pos, 4).toLowerCase() === "sips") {
             result0 = input.substr(pos, 4);
             pos += 4;
           } else {
@@ -3079,9 +3068,21 @@ module.exports = (function(){
               matchFailed("\"sips\"");
             }
           }
+        if (result0 === null) {
+          pos0 = pos;
+          
+          if (input.substr(pos, 3).toLowerCase() === "sip") {
+          result0 = input.substr(pos, 3);
+          pos += 3;
+        } else {
+          result0 = null;
+          if (reportFailures === 0) {
+            matchFailed("\"sip\"");
+          }
+        }
           if (result0 !== null) {
             result0 = (function(offset) {
-                              data.scheme = uri_scheme.toLowerCase(); })(pos0);
+                              data.scheme = result0.toLowerCase(); })(pos0);
           }
           if (result0 === null) {
             pos = pos0;


### PR DESCRIPTION
If sip client uses sips protocol error:  
`error parsing "From" header field with value occurs`

Seems that parsing of uri scheme has incorrect logic. First of all must be parsed *sips* protocol and then *sip*

Example of header:

`
<sips:5000000246@host.com>;tag=Ka7al2s~f
`