### PR TITLE
Correct contact headers for REGISTER

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -957,7 +957,7 @@ UA.prototype.loadConfig = function(configuration) {
   this.contact = {
     pub_gruu: null,
     temp_gruu: null,
-    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'ws'}),
+    uri: new URI('sip', settings.uri.user, settings.via_host, null, {transport: 'ws'}),
     toString: function(options) {
       options = options || {};
 


### PR DESCRIPTION
Some backends (like huaweiATS9900) need Contact header with real login.