### PR TITLE
hack_username_in_contact parameter

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -834,6 +834,7 @@ UA.prototype.loadConfig = function(configuration) {
     * Value to be set in Via sent_by and host part of Contact FQDN
     */
     via_host: Utils.createRandomToken(12) + '.invalid',
+    uri_user: Utils.createRandomToken(8),
 
     // Password
     password: null,
@@ -860,6 +861,7 @@ UA.prototype.loadConfig = function(configuration) {
     hack_via_tcp: false,
     hack_via_ws: false,
     hack_ip_in_contact: false,
+    hack_contact_username: false,
 
     // Options for Node.
     node_websocket_options: {}
@@ -954,10 +956,15 @@ UA.prototype.loadConfig = function(configuration) {
     settings.via_host = Utils.getRandomTestNetIP();
   }
 
+  // Hack username passed in contact for some server, is equal to uri.user if set to true or just grabbed assuming it is string
+  if (settings.hack_contact_username) {
+    settings.uri_user = (settings.hack_contact_username === true) ? settings.uri.user : settings.hack_contact_username;
+  }
+
   this.contact = {
     pub_gruu: null,
     temp_gruu: null,
-    uri: new URI('sip', Utils.createRandomToken(8), settings.via_host, null, {transport: 'ws'}),
+    uri: new URI('sip', settings.uri_user, settings.via_host, null, {transport: 'ws'}),
     toString: function(options) {
       options = options || {};
 
@@ -1038,6 +1045,7 @@ UA.configuration_skeleton = (function() {
       'hack_via_tcp', // false
       'hack_via_ws', // false
       'hack_ip_in_contact', //false
+      'hack_contact_username', //false
       'instance_id',
       'no_answer_timeout', // 30 seconds
       'session_timers', // true
@@ -1049,7 +1057,8 @@ UA.configuration_skeleton = (function() {
 
       // Post-configuration generated parameters
       'via_core_value',
-      'via_host'
+      'via_host',
+      'uri_user'
     ];
 
   for(idx in parameters) {
@@ -1213,6 +1222,12 @@ UA.configuration_check = {
     hack_ip_in_contact: function(hack_ip_in_contact) {
       if (typeof hack_ip_in_contact === 'boolean') {
         return hack_ip_in_contact;
+      }
+    },
+
+    hack_contact_username: function(hack_contact_username) {
+      if (typeof hack_contact_username === 'boolean' || typeof hack_contact_username === 'string') {
+        return hack_contact_username;
       }
     },
 


### PR DESCRIPTION
Logical addition to hack_ip_in_contact parameter. For some strict servers.
If we can use any string in contact why not to give user chance to set its own (:

Input values:
false - random string (default)
true - uri.user
string - string given by client config