### PR TITLE
Proposing to replace non-existent `parsed.error`

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -251,7 +251,7 @@ Parser.parseMessage = function(data, ua) {
     }
     // data.indexOf returned -1 due to a malformed message.
     else if(headerEnd === -1) {
-      parsed.error('parseMessage() | malformed message');
+      debugerror('parseMessage() | malformed message');
       return;
     }
 


### PR DESCRIPTION
`TypeError: parsed.error is not a function`