### PR TITLE
fixed lowercase of URI parameters. Some parameters have to be in same cas for transaction matching.

### DIFF
--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -6080,7 +6080,7 @@ module.exports = (function(){
                               else {
                                 value = value[1];
                               }
-                              data.uri_params[param.toLowerCase()] = value && value.toLowerCase();})(pos0, result0[0], result0[1]);
+                              data.uri_params[param.toLowerCase()] = value;})(pos0, result0[0], result0[1]);
         }
         if (result0 === null) {
           pos = pos0;

--- a/lib/URI.js
+++ b/lib/URI.js
@@ -74,7 +74,7 @@ function URI(scheme, user, host, port, parameters, headers) {
 URI.prototype = {
   setParam: function(key, value) {
     if(key) {
-      this.parameters[key.toLowerCase()] = (typeof value === 'undefined' || value === null) ? null : value.toString().toLowerCase();
+      this.parameters[key.toLowerCase()] = (typeof value === 'undefined' || value === null) ? null : value.toString();
     }
   },
 

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -153,7 +153,7 @@ module.exports = {
     // Alter data.
     c3.uri.setParam('newUriParam', 'zxCV');
     c3.setParam('newHeaderParam', 'zxCV');
-    test.strictEqual(c3.toString(), '<sip:domain.com:5;newuriparam=zxcv>;newheaderparam=zxCV');
+    test.strictEqual(c3.toString(), '<sip:domain.com:5;newuriparam=zxCV>;newheaderparam=zxCV');
 
     test.done();
   },


### PR DESCRIPTION
i.e. ngcpct=c2lwOjEyNy4wLjAuMTo1MDgw vs ngcpct=c2lwojeyny4wljaumto1mdgw 

JsSIP sends:
ACK sip:ngcp-lb@1.2.1.55:5060;ngcpct=c2lwojeyny4wljaumto1mdgw SIP/2.0 

but must be:
ACK sip:ngcp-lb@1.2.1.55:5060;ngcpct=c2lwOjEyNy4wLjAuMTo1MDgw SIP/2.0 
