### PR TITLE
sdp replacements: new RTCSession API methods to replace the SDP

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -575,8 +575,11 @@ RTCSession.prototype.answer = function(options) {
     }
 
     if (! self.late_sdp) {
+      var e = {originator:'remote', type:'offer', sdp:request.body};
+      self.emit('sdp', e);
+
       self.connection.setRemoteDescription(
-        new rtcninja.RTCSessionDescription({type:'offer', sdp:request.body}),
+        new rtcninja.RTCSessionDescription(e),
         // success
         remoteDescriptionSucceededOrNotNeeded,
         // failure
@@ -1249,8 +1252,11 @@ RTCSession.prototype.receiveRequest = function(request) {
             break;
           }
 
+          var e = {originator:'remote', type:'answer', sdp:request.body};
+          this.emit('sdp', e);
+
           this.connection.setRemoteDescription(
-            new rtcninja.RTCSessionDescription({type:'answer', sdp:request.body}),
+            new rtcninja.RTCSessionDescription(e),
             // success
             function() {
               if (!self.is_confirmed) {
@@ -1532,7 +1538,12 @@ function createLocalDescription(type, onSuccess, onFailure, constraints) {
       if (! candidate) {
         connection.onicecandidate = null;
         self.rtcReady = true;
-        if (onSuccess) { onSuccess(connection.localDescription.sdp); }
+
+        if (onSuccess) {
+          var e = {originator:'local', type:type, sdp:connection.localDescription.sdp};
+          self.emit('sdp', e);
+          onSuccess(e.sdp);
+        }
         onSuccess = null;
       }
     };
@@ -1542,7 +1553,12 @@ function createLocalDescription(type, onSuccess, onFailure, constraints) {
       function() {
         if (connection.iceGatheringState === 'complete') {
           self.rtcReady = true;
-          if (onSuccess) { onSuccess(connection.localDescription.sdp); }
+
+          if (onSuccess) {
+            var e = {originator:'local', type:type, sdp:connection.localDescription.sdp};
+            self.emit('sdp', e);
+            onSuccess(e.sdp);
+          }
           onSuccess = null;
         }
       },
@@ -1688,8 +1704,11 @@ function receiveReinvite(request) {
       }
     }
 
+    var e = {originator:'remote', type:'offer', sdp:request.body};
+    this.emit('sdp', e);
+
     this.connection.setRemoteDescription(
-      new rtcninja.RTCSessionDescription({type:'offer', sdp:request.body}),
+      new rtcninja.RTCSessionDescription(e),
       // success
       answer,
       // failure
@@ -1830,8 +1849,11 @@ function receiveUpdate(request) {
     }
   }
 
+  var e = {originator:'remote', type:'offer', sdp:request.body};
+  this.emit('sdp', e);
+
   this.connection.setRemoteDescription(
-    new rtcninja.RTCSessionDescription({type:'offer', sdp:request.body}),
+    new rtcninja.RTCSessionDescription(e),
     // success
     function() {
       if (self.remoteHold === true && hold === false) {
@@ -2099,7 +2121,7 @@ function sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream) 
 function receiveInviteResponse(response) {
   debug('receiveInviteResponse()');
 
-  var cause, dialog,
+  var cause, dialog, e,
     self = this;
 
   // Handle 2XX retransmissions and responses from forked requests
@@ -2189,8 +2211,11 @@ function receiveInviteResponse(response) {
         break;
       }
 
+      e = {originator:'remote', type:'pranswer', sdp:response.body};
+      this.emit('sdp', e);
+
       this.connection.setRemoteDescription(
-        new rtcninja.RTCSessionDescription({type:'pranswer', sdp:response.body}),
+        new rtcninja.RTCSessionDescription(e),
         // success
         null,
         // failure
@@ -2212,8 +2237,11 @@ function receiveInviteResponse(response) {
         break;
       }
 
+      e = {originator:'remote', type:'answer', sdp:response.body};
+      this.emit('sdp', e);
+
       this.connection.setRemoteDescription(
-        new rtcninja.RTCSessionDescription({type:'answer', sdp:response.body}),
+        new rtcninja.RTCSessionDescription(e),
         // success
         function() {
           // Handle Session Timers.
@@ -2320,8 +2348,11 @@ function sendReinvite(options) {
       return;
     }
 
+    var e = {originator:'remote', type:'answer', sdp:response.body};
+    self.emit('sdp', e);
+
     self.connection.setRemoteDescription(
-      new rtcninja.RTCSessionDescription({type:'answer', sdp:response.body}),
+      new rtcninja.RTCSessionDescription(e),
       // success
       function() {
         if (eventHandlers.succeeded) { eventHandlers.succeeded(response); }
@@ -2450,8 +2481,11 @@ function sendUpdate(options) {
         return;
       }
 
+      var e = {originator:'remote', type:'answer', sdp:response.body};
+      self.emit('sdp', e);
+
       self.connection.setRemoteDescription(
-        new rtcninja.RTCSessionDescription({type:'answer', sdp:response.body}),
+        new rtcninja.RTCSessionDescription(e),
         // success
         function() {
           if (eventHandlers.succeeded) { eventHandlers.succeeded(response); }


### PR DESCRIPTION
These methods may be defined by the user in order to modify the given SDP.

- receivedSDP({type:type, sdp:sdp}) is executed before passing a remote
  SDP to RTCPeerConnection.

- sendingSDP({type:type, sdp:sdp}) is executed before sending a local SDP.