### PR TITLE
JsSIP Socket interface

### DIFF
--- a/lib/SIPMessage.js
+++ b/lib/SIPMessage.js
@@ -53,7 +53,7 @@ function OutgoingRequest(method, ruri, ua, params, extraHeaders, body) {
   if (params.route_set) {
     this.setHeader('route', params.route_set);
   } else if (ua.configuration.use_preloaded_route){
-    this.setHeader('route', ua.transport.server.sip_uri);
+    this.setHeader('route', ua.transport.sip_uri);
   }
 
   // Via

--- a/lib/Socket.js
+++ b/lib/Socket.js
@@ -1,0 +1,62 @@
+module.exports = Socket;
+
+/**
+ * Interface documentation: http://jssip.net/documentation/$last_version/api/socket/
+ *
+ * interface Socket {
+ *  attribute String via_transport
+ *  attribute String url
+ *  attribute String sip_uri
+ *
+ *  method connect();
+ *  method disconnect();
+ *  method send(data);
+ *
+ *  attribute EventHandler onconnect
+ *  attribute EventHandler ondisconnect
+ *  attribute EventHandler ondata
+ * }
+ *
+ */
+
+
+/**
+ * Dependencies.
+ */
+var Utils =       require('./Utils');
+var debugerror =  require('debug')('JsSIP:ERROR:Socket');
+
+function Socket() {}
+
+Socket.isSocket = function(socket) {
+  if (typeof socket === 'undefined') {
+    debugerror('Undefined JsSIP.Socket instance');
+    return false;
+  }
+
+  // Check Properties
+  try {
+    ['via_transport', 'url', 'sip_uri'].forEach(function(prop) {
+      if (!Utils.isString(socket[prop])) {
+        debugerror('Missing or invalid JsSIP.Socket property: '+ prop);
+        throw new Error();
+      }
+    });
+  } catch(e) {
+    return false;
+  }
+
+  // Check Methods
+  try {
+    ['connect', 'disconnect', 'send'].forEach(function(method) {
+      if (!Utils.isFunction(socket[method])) {
+        debugerror('Missing or invalid JsSIP.Socket method: '+ method);
+        throw new Error();
+      }
+    });
+  } catch(e) {
+    return false;
+  }
+
+  return true;
+};

--- a/lib/Transactions.js
+++ b/lib/Transactions.js
@@ -47,8 +47,7 @@ var Timers = require('./Timers');
 
 
 function NonInviteClientTransaction(request_sender, request, transport) {
-  var via,
-    via_transport;
+  var via;
 
   this.type = C.NON_INVITE_CLIENT;
   this.transport = transport;
@@ -56,17 +55,7 @@ function NonInviteClientTransaction(request_sender, request, transport) {
   this.request_sender = request_sender;
   this.request = request;
 
-  if (request_sender.ua.configuration.hack_via_tcp) {
-    via_transport = 'TCP';
-  }
-  else if (request_sender.ua.configuration.hack_via_ws) {
-    via_transport = 'WS';
-  }
-  else {
-    via_transport = transport.server.scheme;
-  }
-
-  via = 'SIP/2.0/' + via_transport;
+  via = 'SIP/2.0/' + transport.via_transport;
   via += ' ' + request_sender.ua.configuration.via_host + ';branch=' + this.id;
 
   this.request.setHeader('via', via);
@@ -152,8 +141,7 @@ NonInviteClientTransaction.prototype.receiveResponse = function(response) {
 
 function InviteClientTransaction(request_sender, request, transport) {
   var via,
-    tr = this,
-    via_transport;
+    tr = this;
 
   this.type = C.INVITE_CLIENT;
   this.transport = transport;
@@ -161,17 +149,7 @@ function InviteClientTransaction(request_sender, request, transport) {
   this.request_sender = request_sender;
   this.request = request;
 
-  if (request_sender.ua.configuration.hack_via_tcp) {
-    via_transport = 'TCP';
-  }
-  else if (request_sender.ua.configuration.hack_via_ws) {
-    via_transport = 'WS';
-  }
-  else {
-    via_transport = transport.server.scheme;
-  }
-
-  via = 'SIP/2.0/' + via_transport;
+  via = 'SIP/2.0/' + transport.via_transport;
   via += ' ' + request_sender.ua.configuration.via_host + ';branch=' + this.id;
 
   this.request.setHeader('via', via);
@@ -345,25 +323,14 @@ InviteClientTransaction.prototype.receiveResponse = function(response) {
 
 
 function AckClientTransaction(request_sender, request, transport) {
-  var via,
-    via_transport;
+  var via;
 
   this.transport = transport;
   this.id = 'z9hG4bK' + Math.floor(Math.random() * 10000000);
   this.request_sender = request_sender;
   this.request = request;
 
-  if (request_sender.ua.configuration.hack_via_tcp) {
-    via_transport = 'TCP';
-  }
-  else if (request_sender.ua.configuration.hack_via_ws) {
-    via_transport = 'WS';
-  }
-  else {
-    via_transport = transport.server.scheme;
-  }
-
-  via = 'SIP/2.0/' + via_transport;
+  via = 'SIP/2.0/' + transport.via_transport;
   via += ' ' + request_sender.ua.configuration.via_host + ';branch=' + this.id;
 
   this.request.setHeader('via', via);

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -1,291 +1,290 @@
 module.exports = Transport;
 
-
-var C = {
-  // Transport status codes
-  STATUS_READY:        0,
-  STATUS_DISCONNECTED: 1,
-  STATUS_ERROR:        2
-};
-
-
-/**
- * Expose C object.
- */
-Transport.C = C;
-
-
 /**
  * Dependencies.
  */
+var Socket = require('./Socket');
 var debug = require('debug')('JsSIP:Transport');
 var debugerror = require('debug')('JsSIP:ERROR:Transport');
-debugerror.log = console.warn.bind(console);
-var JsSIP_C = require('./Constants');
-var Parser = require('./Parser');
-var UA = require('./UA');
-var SIPMessage = require('./SIPMessage');
-var sanityCheck = require('./sanityCheck');
-// 'websocket' module uses the native WebSocket interface when bundled to run in a browser.
-var W3CWebSocket = require('websocket').w3cwebsocket;
 
+/**
+ * Constants
+ */
+var C = {
+  // Transport status
+  STATUS_CONNECTED:           0,
+  STATUS_CONNECTING:          1,
+  STATUS_DISCONNECTED:        2,
 
-function Transport(ua, server) {
-  this.ua = ua;
-  this.ws = null;
-  this.server = server;
-  this.reconnection_attempts = 0;
-  this.closed = false;
-  this.connected = false;
-  this.reconnectTimer = null;
-  this.lastTransportError = {};
+  // Socket status
+  SOCKET_STATUS_READY:        0,
+  SOCKET_STATUS_ERROR:        1,
 
-  /**
-   * Options for the Node "websocket" library.
-   */
-
-  this.node_websocket_options = this.ua.configuration.node_websocket_options || {};
-
-  // Add our User-Agent header.
-  this.node_websocket_options.headers = this.node_websocket_options.headers || {};
-  this.node_websocket_options.headers['User-Agent'] = JsSIP_C.USER_AGENT;
-}
-
-Transport.prototype = {
-
-  /**
-  * Connect socket.
-  */
-  connect: function() {
-    var transport = this;
-
-    if(this.ws && (this.ws.readyState === this.ws.OPEN || this.ws.readyState === this.ws.CONNECTING)) {
-      debug('WebSocket ' + this.server.ws_uri + ' is already connected');
-      return false;
-    }
-
-    if(this.ws) {
-      this.ws.close();
-    }
-
-    debug('connecting to WebSocket ' + this.server.ws_uri);
-    this.ua.onTransportConnecting(this,
-      (this.reconnection_attempts === 0)?1:this.reconnection_attempts);
-
-    try {
-      // Hack in case W3CWebSocket is not the class exported by Node-WebSocket
-      // (may just happen if the above `var W3CWebSocket` line is overriden by
-      // `var W3CWebSocket = global.W3CWebSocket`).
-      if (W3CWebSocket.length > 3) {
-        this.ws = new W3CWebSocket(this.server.ws_uri, 'sip', this.node_websocket_options.origin, this.node_websocket_options.headers, this.node_websocket_options.requestOptions, this.node_websocket_options.clientConfig);
-      } else {
-        this.ws = new W3CWebSocket(this.server.ws_uri, 'sip');
-      }
-
-      this.ws.binaryType = 'arraybuffer';
-
-      this.ws.onopen = function() {
-        transport.onOpen();
-      };
-
-      this.ws.onclose = function(e) {
-        transport.onClose(e);
-      };
-
-      this.ws.onmessage = function(e) {
-        transport.onMessage(e);
-      };
-
-      this.ws.onerror = function(e) {
-        transport.onError(e);
-      };
-    } catch(e) {
-      debugerror('error connecting to WebSocket ' + this.server.ws_uri + ': ' + e);
-      this.lastTransportError.code = null;
-      this.lastTransportError.reason = e.message;
-      this.ua.onTransportError(this);
-    }
-  },
-
-  /**
-  * Disconnect socket.
-  */
-  disconnect: function() {
-    if(this.ws) {
-      // Clear reconnectTimer
-      clearTimeout(this.reconnectTimer);
-      // TODO: should make this.reconnectTimer = null here?
-
-      this.closed = true;
-      debug('closing WebSocket ' + this.server.ws_uri);
-      this.ws.close();
-    }
-
-    // TODO: Why this??
-    if (this.reconnectTimer !== null) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-      this.ua.onTransportDisconnected({
-        transport: this,
-        code: this.lastTransportError.code,
-        reason: this.lastTransportError.reason
-      });
-    }
-  },
-
-  /**
-   * Send a message.
-   */
-  send: function(msg) {
-    var message = msg.toString();
-
-    if(this.ws && this.ws.readyState === this.ws.OPEN) {
-      debug('sending WebSocket message:\n%s\n', message);
-      this.ws.send(message);
-      return true;
-    } else {
-      debugerror('unable to send message, WebSocket is not open');
-      return false;
-    }
-  },
-
-  // Transport Event Handlers
-
-  onOpen: function() {
-    this.connected = true;
-
-    debug('WebSocket ' + this.server.ws_uri + ' connected');
-    // Clear reconnectTimer since we are not disconnected
-    if (this.reconnectTimer !== null) {
-      clearTimeout(this.reconnectTimer);
-      this.reconnectTimer = null;
-    }
-    // Reset reconnection_attempts
-    this.reconnection_attempts = 0;
-    // Disable closed
-    this.closed = false;
-    // Trigger onTransportConnected callback
-    this.ua.onTransportConnected(this);
-  },
-
-  onClose: function(e) {
-    var connected_before = this.connected;
-
-    this.connected = false;
-    this.lastTransportError.code = e.code;
-    this.lastTransportError.reason = e.reason;
-    debug('WebSocket disconnected (code: ' + e.code + (e.reason? '| reason: ' + e.reason : '') +')');
-
-    if(e.wasClean === false) {
-      debugerror('WebSocket abrupt disconnection');
-    }
-    // Transport was connected
-    if (connected_before === true) {
-      this.ua.onTransportClosed(this);
-
-      // Check whether the user requested to close.
-      if(!this.closed) {
-        this.reConnect();
-      }
-    } else {
-      // This is the first connection attempt
-      // May be a network error (or may be UA.stop() was called)
-      this.ua.onTransportError(this);
-    }
-  },
-
-  onMessage: function(e) {
-    var message, transaction,
-      data = e.data;
-
-    // CRLF Keep Alive response from server. Ignore it.
-    if(data === '\r\n') {
-      debug('received WebSocket message with CRLF Keep Alive response');
-      return;
-    }
-
-    // WebSocket binary message.
-    else if (typeof data !== 'string') {
-      try {
-        data = String.fromCharCode.apply(null, new Uint8Array(data));
-      } catch(evt) {
-        debugerror('received WebSocket binary message failed to be converted into string, message discarded');
-        return;
-      }
-
-      debug('received WebSocket binary message:\n%s\n', data);
-    }
-
-    // WebSocket text message.
-    else {
-      debug('received WebSocket text message:\n%s\n', data);
-    }
-
-    message = Parser.parseMessage(data, this.ua);
-
-    if (! message) {
-      return;
-    }
-
-    if(this.ua.status === UA.C.STATUS_USER_CLOSED && message instanceof SIPMessage.IncomingRequest) {
-      return;
-    }
-
-    // Do some sanity check
-    if(! sanityCheck(message, this.ua, this)) {
-      return;
-    }
-
-    if(message instanceof SIPMessage.IncomingRequest) {
-      message.transport = this;
-      this.ua.receiveRequest(message);
-    } else if(message instanceof SIPMessage.IncomingResponse) {
-      /* Unike stated in 18.1.2, if a response does not match
-      * any transaction, it is discarded here and no passed to the core
-      * in order to be discarded there.
-      */
-      switch(message.method) {
-        case JsSIP_C.INVITE:
-          transaction = this.ua.transactions.ict[message.via_branch];
-          if(transaction) {
-            transaction.receiveResponse(message);
-          }
-          break;
-        case JsSIP_C.ACK:
-          // Just in case ;-)
-          break;
-        default:
-          transaction = this.ua.transactions.nict[message.via_branch];
-          if(transaction) {
-            transaction.receiveResponse(message);
-          }
-          break;
-      }
-    }
-  },
-
-  onError: function(e) {
-    debugerror('WebSocket connection error: %o', e);
-  },
-
-  /**
-  * Reconnection attempt logic.
-  */
-  reConnect: function() {
-    var transport = this;
-
-    this.reconnection_attempts += 1;
-
-    if(this.reconnection_attempts > this.ua.configuration.ws_server_max_reconnection) {
-      debugerror('maximum reconnection attempts for WebSocket ' + this.server.ws_uri);
-      this.ua.onTransportError(this);
-    } else {
-      debug('trying to reconnect to WebSocket ' + this.server.ws_uri + ' (reconnection attempt ' + this.reconnection_attempts + ')');
-
-      this.reconnectTimer = setTimeout(function() {
-        transport.connect();
-        transport.reconnectTimer = null;
-      }, this.ua.configuration.ws_server_reconnection_timeout * 1000);
-    }
+  // Recovery options
+  recovery_options: {
+    min_interval: 2, // minimum interval in seconds between recover attempts
+    max_interval: 30 // maximum interval in seconds between recover attempts
   }
 };
+
+/*
+ * Manages one or multiple JsSIP.Socket instances.
+ * Is reponsible for transport recovery logic among all socket instances.
+ *
+ * @socket JsSIP::Socket instance
+ */
+
+function Transport(sockets, recovery_options) {
+  debug('new()');
+
+  this.status = C.STATUS_DISCONNECTED;
+
+  // current socket
+  this.socket = null;
+
+  // socket collection
+  this.sockets = [];
+
+  this.recovery_options = recovery_options || C.recovery_options;
+  this.recover_attempts = 0;
+  this.recovery_timer = null;
+
+  this.close_requested = false;
+
+  if (typeof sockets === 'undefined') {
+    throw new TypeError('Invalid argument.' +
+                        ' undefined \'sockets\' argument');
+  }
+
+  if (!(sockets instanceof Array)) {
+    sockets = [ sockets ];
+  }
+
+  sockets.forEach(function(socket) {
+    if (!Socket.isSocket(socket.socket)) {
+      throw new TypeError('Invalid argument.' +
+                          ' invalid \'JsSIP.Socket\' instance');
+    }
+
+    if (socket.weight && !Number(socket.weight)) {
+      throw new TypeError('Invalid argument.' +
+                          ' \'weight\' attribute is not a number');
+    }
+
+    this.sockets.push({
+      socket: socket.socket,
+      weight: socket.weight || 0,
+      status: C.SOCKET_STATUS_READY
+    });
+  }, this);
+
+  // read only properties
+  Object.defineProperties(this, {
+    via_transport:   { get: function() { return this.socket.via_transport; } },
+    url:      { get: function() { return this.socket.url;       } },
+    sip_uri:  { get: function() { return this.socket.sip_uri;   } }
+  });
+
+  // get the socket with higher weight
+  getSocket.call(this);
+}
+
+/**
+ * Instance Methods
+ */
+
+Transport.prototype.connect = function() {
+  debug('connect()');
+
+  if (this.isConnected()) {
+    debug('Transport is already connected');
+    return;
+  } else if (this.isConnecting()) {
+    debug('Transport is connecting');
+    return;
+  }
+
+  this.close_requested = false;
+  this.status = C.STATUS_CONNECTING;
+  this.onconnecting({ socket:this.socket, attempts:this.recover_attempts });
+
+  if (!this.close_requested) {
+    // bind socket event callbacks
+    this.socket.onconnect     = onConnect.bind(this);
+    this.socket.ondisconnect  = onDisconnect.bind(this);
+    this.socket.ondata        = onData.bind(this);
+
+    this.socket.connect();
+  }
+
+  return;
+};
+
+Transport.prototype.disconnect = function() {
+  debug('close()');
+
+  this.close_requested = true;
+  this.recover_attempts = 0;
+  this.status = C.STATUS_DISCONNECTED;
+
+  // clear recovery_timer
+  if (this.recovery_timer !== null) {
+    clearTimeout(this.recovery_timer);
+    this.recovery_timer = null;
+  }
+
+  // unbind socket event callbacks
+  this.socket.onconnect     = function() {};
+  this.socket.ondisconnect  = function() {};
+  this.socket.ondata        = function() {};
+
+  this.socket.disconnect();
+  this.ondisconnect();
+};
+
+Transport.prototype.send = function(data) {
+  debug('send()');
+
+  if (!this.isConnected()) {
+    debugerror('unable to send message, transport is not connected');
+    return false;
+  }
+
+  var message = data.toString();
+
+  debug('sending message:\n\n' + message + '\n');
+  return this.socket.send(message);
+};
+
+Transport.prototype.isConnected = function() {
+  return this.status === C.STATUS_CONNECTED;
+};
+
+Transport.prototype.isConnecting = function() {
+  return this.status === C.STATUS_CONNECTING;
+};
+
+/**
+ * Socket Event Handlers
+ */
+
+function onConnect() {
+  this.recover_attempts = 0;
+  this.status = C.STATUS_CONNECTED;
+
+  // clear recovery_timer
+  if (this.recovery_timer !== null) {
+    clearTimeout(this.recovery_timer);
+    this.recovery_timer = null;
+  }
+
+  this.onconnect( {socket:this} );
+}
+
+function onDisconnect(error, code, reason) {
+  this.status = C.STATUS_DISCONNECTED;
+  this.ondisconnect({ socket:this.socket, error:error, code:code, reason:reason });
+
+  if (this.close_requested) {
+    return;
+  }
+
+  // update socket status
+  if (error) {
+    this.socket.status = C.SOCKET_STATUS_ERROR;
+  }
+
+  reconnect.call(this, error);
+}
+
+function onData(data) {
+  // CRLF Keep Alive response from server. Ignore it.
+  if(data === '\r\n') {
+    debug('received message with CRLF Keep Alive response');
+    return;
+  }
+
+  // binary message.
+  else if (typeof data !== 'string') {
+    try {
+      data = String.fromCharCode.apply(null, new Uint8Array(data));
+    } catch(evt) {
+      debug('received binary message failed to be converted into string,' +
+            ' message discarded');
+      return;
+    }
+
+    debug('received binary message:\n\n' + data + '\n');
+  }
+
+  // text message.
+  else {
+    debug('received text message:\n\n' + data + '\n');
+  }
+
+  this.ondata({ transport:this, message:data });
+}
+
+function reconnect() {
+  var k,
+  self = this;
+
+  this.recover_attempts+=1;
+
+  k = Math.floor((Math.random() * Math.pow(2,this.recover_attempts)) +1);
+
+  if (k < this.recovery_options.min_interval) {
+    k = this.recovery_options.min_interval;
+  }
+
+  else if (k > this.recovery_options.max_interval) {
+    k = this.recovery_options.max_interval;
+  }
+
+  debug('reconnection attempt: '+ this.recover_attempts +
+        '. next connection attempt in '+ k +' seconds');
+
+  this.recovery_timer = setTimeout(function() {
+    if (!self.close_requested && !(self.isConnected() || self.isConnecting())) {
+      // get the next available socket with higher weight
+      getSocket.call(self);
+
+      // connect the socket
+      self.connect();
+    }
+  }, k * 1000);
+}
+
+/**
+ * get the next available socket with higher weight
+ */
+function getSocket() {
+
+  var candidates = [];
+
+  this.sockets.forEach(function(socket) {
+    if (socket.status === C.SOCKET_STATUS_ERROR) {
+      return; // continue the array iteration
+    } else if (candidates.length === 0) {
+      candidates.push(socket);
+    } else if (socket.weight > candidates[0].weight) {
+      candidates = [socket];
+    } else if (socket.weight === candidates[0].weight) {
+      candidates.push(socket);
+    }
+  });
+
+  if (candidates.length === 0) {
+    // all sockets have failed. reset sockets status
+    this.sockets.forEach(function(socket) {
+      socket.status = C.SOCKET_STATUS_READY;
+    });
+
+    // get next available socket
+    getSocket.call(this);
+    return;
+  }
+
+  var idx = Math.floor((Math.random()* candidates.length));
+  this.socket = candidates[idx].socket;
+}

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -1,3 +1,5 @@
+/*jshint -W079 */ // ignore warning about redefinition of 'WebSocket'. It's secure.
+
 module.exports = UA;
 
 
@@ -32,13 +34,17 @@ var JsSIP_C = require('./Constants');
 var Registrator = require('./Registrator');
 var RTCSession = require('./RTCSession');
 var Message = require('./Message');
+var Transactions = require('./Transactions');
 var Transport = require('./Transport');
-var Transactions = require('./Transactions');
-var Transactions = require('./Transactions');
+var WebSocket = require('./WebSocket');
+var Socket = require('./Socket');
 var Utils = require('./Utils');
 var Exceptions = require('./Exceptions');
 var URI = require('./URI');
 var Grammar = require('./Grammar');
+var Parser = require('./Parser');
+var SIPMessage = require('./SIPMessage');
+var sanityCheck = require('./sanityCheck');
 
 
 
@@ -75,9 +81,6 @@ function UA(configuration) {
 
   // Custom UA empty object for high level use
   this.data = {};
-
-  this.transportRecoverAttempts = 0;
-  this.transportRecoveryTimer = null;
 
   Object.defineProperties(this, {
     transactionsCount: {
@@ -154,14 +157,13 @@ util.inherits(UA, events.EventEmitter);
 //=================
 
 /**
- * Connect to the WS server if status = STATUS_INIT.
+ * Connect to the server if status = STATUS_INIT.
  * Resume UA after being closed.
  */
 UA.prototype.start = function() {
   debug('start()');
 
-  var server,
-      self = this;
+  var self = this;
 
   function connect() {
     debug('restarting UA');
@@ -170,8 +172,6 @@ UA.prototype.start = function() {
   }
 
   if (this.status === C.STATUS_INIT) {
-    server = this.getNextWsServer();
-    this.transport = new Transport(this, server);
     this.transport.connect();
   } else if(this.status === C.STATUS_USER_CLOSED) {
     if (!this.isConnected()) {
@@ -231,11 +231,7 @@ UA.prototype.isRegistered = function() {
  * Connection state.
  */
 UA.prototype.isConnected = function() {
-  if(this.transport) {
-    return this.transport.connected;
-  } else {
-    return false;
-  }
+  return this.transport.isConnected();
 };
 
 /**
@@ -310,9 +306,6 @@ UA.prototype.stop = function() {
     debug('UA already closed');
     return;
   }
-
-  // Clear transportRecoveryTimer
-  clearTimeout(this.transportRecoveryTimer);
 
   // Close registrator
   this._registrator.close();
@@ -442,119 +435,6 @@ UA.prototype.set = function(parameter, value) {
 //==========================
 // Event Handlers
 //==========================
-
-/**
- * Transport Close event.
- */
-UA.prototype.onTransportClosed = function(transport) {
-  // Run _onTransportError_ callback on every client transaction using _transport_
-  var type, idx, length,
-  client_transactions = ['nict', 'ict', 'nist', 'ist'];
-
-  transport.server.status = Transport.C.STATUS_DISCONNECTED;
-
-  length = client_transactions.length;
-  for (type = 0; type < length; type++) {
-    for(idx in this.transactions[client_transactions[type]]) {
-      this.transactions[client_transactions[type]][idx].onTransportError();
-    }
-  }
-
-  this.emit('disconnected', {
-    transport: transport,
-    code: transport.lastTransportError.code,
-    reason: transport.lastTransportError.reason
-  });
-
-  // Call registrator _onTransportClosed_
-  this._registrator.onTransportClosed();
-};
-
-/**
- * Unrecoverable transport event.
- * Connection reattempt logic has been done and didn't success.
- */
-UA.prototype.onTransportError = function(transport) {
-  var server;
-
-  debug('transport ' + transport.server.ws_uri + ' failed | connection state set to '+ Transport.C.STATUS_ERROR);
-
-  // Close sessions.
-  // Mark this transport as 'down' and try the next one
-  transport.server.status = Transport.C.STATUS_ERROR;
-
-  this.emit('disconnected', {
-    transport: transport,
-    code: transport.lastTransportError.code,
-    reason: transport.lastTransportError.reason
-  });
-
-  // Don't attempt to recover the connection if the user closes the UA.
-  if (this.status === C.STATUS_USER_CLOSED) {
-    return;
-  }
-
-  server = this.getNextWsServer();
-
-  if(server) {
-    this.transport = new Transport(this, server);
-    this.transport.connect();
-  } else {
-    this.closeSessionsOnTransportError();
-    if (!this.error || this.error !== C.NETWORK_ERROR) {
-      this.status = C.STATUS_NOT_READY;
-      this.error = C.NETWORK_ERROR;
-    }
-    // Transport Recovery process
-    this.recoverTransport();
-  }
-};
-
-/**
- * Transport connection event.
- */
-UA.prototype.onTransportConnected = function(transport) {
-  this.transport = transport;
-
-  // Reset transport recovery counter
-  this.transportRecoverAttempts = 0;
-
-  transport.server.status = Transport.C.STATUS_READY;
-
-  if(this.status === C.STATUS_USER_CLOSED) {
-    return;
-  }
-
-  this.status = C.STATUS_READY;
-  this.error = null;
-
-  this.emit('connected', {
-    transport: transport
-  });
-
-  if(this.dynConfiguration.register) {
-    this._registrator.register();
-  }
-};
-
-
-/**
- * Transport connecting event
- */
-UA.prototype.onTransportConnecting = function(transport, attempts) {
-  this.emit('connecting', {
-    transport: transport,
-    attempts: attempts
-  });
-};
-
-/**
- * Transport connected event
- */
-UA.prototype.onTransportDisconnected = function(data) {
-  this.emit('disconnected', data);
-};
-
 
 /**
  * new Transaction
@@ -798,76 +678,6 @@ UA.prototype.findDialog = function(call_id, from_tag, to_tag) {
   }
 };
 
-/**
- * Retrieve the next server to which connect.
- */
-UA.prototype.getNextWsServer = function() {
-  // Order servers by weight
-  var idx, length, ws_server,
-  candidates = [];
-
-  length = this.configuration.ws_servers.length;
-  for (idx = 0; idx < length; idx++) {
-    ws_server = this.configuration.ws_servers[idx];
-
-    if (ws_server.status === Transport.C.STATUS_ERROR) {
-      continue;
-    } else if (candidates.length === 0) {
-      candidates.push(ws_server);
-    } else if (ws_server.weight > candidates[0].weight) {
-      candidates = [ws_server];
-    } else if (ws_server.weight === candidates[0].weight) {
-      candidates.push(ws_server);
-    }
-  }
-
-  idx = Math.floor((Math.random()* candidates.length));
-  return candidates[idx];
-};
-
-/**
- * Close all sessions on transport error.
- */
-UA.prototype.closeSessionsOnTransportError = function() {
-  var idx;
-
-  // Run _transportError_ for every Session
-  for(idx in this.sessions) {
-    this.sessions[idx].onTransportError();
-  }
-};
-
-UA.prototype.recoverTransport = function(ua) {
-  var idx, length, k, nextRetry, count, server;
-
-  ua = ua || this;
-  count = ua.transportRecoverAttempts;
-
-  length = ua.configuration.ws_servers.length;
-  for (idx = 0; idx < length; idx++) {
-    ua.configuration.ws_servers[idx].status = 0;
-  }
-
-  server = ua.getNextWsServer();
-
-  k = Math.floor((Math.random() * Math.pow(2,count)) +1);
-  nextRetry = k * ua.configuration.connection_recovery_min_interval;
-
-  if (nextRetry > ua.configuration.connection_recovery_max_interval) {
-    debug('time for next connection attempt exceeds connection_recovery_max_interval, resetting counter');
-    nextRetry = ua.configuration.connection_recovery_min_interval;
-    count = 0;
-  }
-
-  debug('next connection attempt in '+ nextRetry +' seconds');
-
-  this.transportRecoveryTimer = setTimeout(function() {
-    ua.transportRecoverAttempts = count + 1;
-    ua.transport = new Transport(ua, server);
-    ua.transport.connect();
-  }, nextRetry * 1000);
-};
-
 UA.prototype.loadConfig = function(configuration) {
   // Settings and default values
   var parameter, value, checked_value, hostport_params, registrar_server,
@@ -891,13 +701,6 @@ UA.prototype.loadConfig = function(configuration) {
     register: true,
     registrar_server: null,
 
-    // Transport related parameters
-    ws_server_max_reconnection: 3,
-    ws_server_reconnection_timeout: 4,
-
-    connection_recovery_min_interval: 2,
-    connection_recovery_max_interval: 30,
-
     use_preloaded_route: false,
 
     // Session parameters
@@ -905,12 +708,7 @@ UA.prototype.loadConfig = function(configuration) {
     session_timers: true,
 
     // Hacks
-    hack_via_tcp: false,
-    hack_via_ws: false,
     hack_ip_in_contact: false,
-
-    // Options for Node.
-    node_websocket_options: {}
   };
 
   // Pre-Configuration
@@ -942,20 +740,13 @@ UA.prototype.loadConfig = function(configuration) {
         continue;
       }
 
-      checked_value = UA.configuration_check.optional[parameter].call(this, value);
+      checked_value = UA.configuration_check.optional[parameter].call(this, value, configuration);
       if (checked_value !== undefined) {
         settings[parameter] = checked_value;
       } else {
         throw new Exceptions.ConfigurationError(parameter, value);
       }
     }
-  }
-
-  // Sanity Checks
-
-  // Connection recovery intervals.
-  if(settings.connection_recovery_max_interval < settings.connection_recovery_min_interval) {
-    throw new Exceptions.ConfigurationError('connection_recovery_max_interval', settings.connection_recovery_max_interval);
   }
 
   // Post Configuration Process
@@ -977,6 +768,43 @@ UA.prototype.loadConfig = function(configuration) {
   hostport_params = settings.uri.clone();
   hostport_params.user = null;
   settings.hostport_params = hostport_params.toString().replace(/^sip:/i, '');
+
+  // Transport
+  var sockets = [];
+  if (settings.ws_servers && Array.isArray(settings.ws_servers)) {
+    sockets = sockets.concat(settings.ws_servers);
+  }
+
+  if (settings.sockets && Array.isArray(settings.sockets)) {
+    sockets = sockets.concat(settings.sockets);
+  }
+
+  if (sockets.length === 0) {
+    throw new Exceptions.ConfigurationError('sockets');
+  }
+
+  try {
+    this.transport = new Transport(sockets, { /* recovery options */
+      max_interval: settings.connection_recovery_max_interval,
+      min_interval: settings.connection_recovery_min_interval
+    });
+
+    // Transport event callbacks
+    this.transport.onconnecting = onTransportConnecting.bind(this);
+    this.transport.onconnect    = onTransportConnect.bind(this);
+    this.transport.ondisconnect = onTransportDisconnect.bind(this);
+    this.transport.ondata       = onTransportData.bind(this);
+
+    // transport options not needed here anymore
+    delete settings.connection_recovery_max_interval;
+    delete settings.connection_recovery_min_interval;
+    delete settings.node_websocket_options;
+    delete settings.ws_servers;
+    delete settings.sockets;
+  } catch (e) {
+    debugerror(e);
+    throw new Exceptions.ConfigurationError('sockets', sockets);
+  }
 
   // Check whether authorization_user is explicitly defined.
   // Take 'settings.uri.user' value if not.
@@ -1071,8 +899,6 @@ UA.configuration_skeleton = (function() {
     parameters = [
       // Internal parameters
       'jssip_id',
-      'ws_server_max_reconnection',
-      'ws_server_reconnection_timeout',
       'hostport_params',
 
       // Mandatory user configurable parameters
@@ -1081,11 +907,7 @@ UA.configuration_skeleton = (function() {
 
       // Optional user configurable parameters
       'authorization_user',
-      'connection_recovery_max_interval',
-      'connection_recovery_min_interval',
       'display_name',
-      'hack_via_tcp', // false
-      'hack_via_ws', // false
       'hack_ip_in_contact', //false
       'instance_id',
       'no_answer_timeout', // 30 seconds
@@ -1153,65 +975,6 @@ UA.configuration_check = {
       } else {
         return parsed;
       }
-    },
-
-    ws_servers: function(ws_servers) {
-      var idx, length, url;
-
-      /* Allow defining ws_servers parameter as:
-       *  String: "host"
-       *  Array of Strings: ["host1", "host2"]
-       *  Array of Objects: [{ws_uri:"host1", weight:1}, {ws_uri:"host2", weight:0}]
-       *  Array of Objects and Strings: [{ws_uri:"host1"}, "host2"]
-       */
-      if (typeof ws_servers === 'string') {
-        ws_servers = [{ws_uri: ws_servers}];
-      } else if (Array.isArray(ws_servers)) {
-        length = ws_servers.length;
-        for (idx = 0; idx < length; idx++) {
-          if (typeof ws_servers[idx] === 'string') {
-            ws_servers[idx] = {ws_uri: ws_servers[idx]};
-          }
-        }
-      } else {
-        return;
-      }
-
-      if (ws_servers.length === 0) {
-        return false;
-      }
-
-      length = ws_servers.length;
-      for (idx = 0; idx < length; idx++) {
-        if (!ws_servers[idx].ws_uri) {
-          debug('ERROR: missing "ws_uri" attribute in ws_servers parameter');
-          return;
-        }
-        if (ws_servers[idx].weight && !Number(ws_servers[idx].weight)) {
-          debug('ERROR: "weight" attribute in ws_servers parameter must be a Number');
-          return;
-        }
-
-        url = Grammar.parse(ws_servers[idx].ws_uri, 'absoluteURI');
-
-        if(url === -1) {
-          debug('ERROR: invalid "ws_uri" attribute in ws_servers parameter: ' + ws_servers[idx].ws_uri);
-          return;
-        } else if(url.scheme !== 'wss' && url.scheme !== 'ws') {
-          debug('ERROR: invalid URI scheme in ws_servers parameter: ' + url.scheme);
-          return;
-        } else {
-          ws_servers[idx].sip_uri = '<sip:' + url.host + (url.port ? ':' + url.port : '') + ';transport=ws;lr>';
-
-          if (!ws_servers[idx].weight) {
-            ws_servers[idx].weight = 0;
-          }
-
-          ws_servers[idx].status = 0;
-          ws_servers[idx].scheme = url.scheme.toUpperCase();
-        }
-      }
-      return ws_servers;
     }
   },
 
@@ -1250,18 +1013,6 @@ UA.configuration_check = {
         return;
       } else {
         return display_name;
-      }
-    },
-
-    hack_via_tcp: function(hack_via_tcp) {
-      if (typeof hack_via_tcp === 'boolean') {
-        return hack_via_tcp;
-      }
-    },
-
-    hack_via_ws: function(hack_via_ws) {
-      if (typeof hack_via_ws === 'boolean') {
-        return hack_via_ws;
       }
     },
 
@@ -1348,10 +1099,175 @@ UA.configuration_check = {
       }
     },
 
+    sockets: function(sockets) {
+      var idx, length;
+
+      /* Allow defining sockets parameter as:
+       *  Socket: socket
+       *  Array of Socket: [socket1, socket2]
+       *  Array of Objects: [{socket: socket1, weight:1}, {socket: Socket2, weight:0}]
+       *  Array of Objects and Socket: [{socket: socket1}, socket2]
+       */
+      if (Socket.isSocket(sockets)) {
+        sockets = [{socket: sockets}];
+      } else if (Array.isArray(sockets) && sockets.length) {
+        length = sockets.length;
+        for (idx = 0; idx < length; idx++) {
+          if (Socket.isSocket(sockets[idx])) {
+            sockets[idx] = {socket: sockets[idx]};
+          }
+        }
+      } else {
+        return;
+      }
+
+      return sockets;
+    },
+
     use_preloaded_route: function(use_preloaded_route) {
       if (typeof use_preloaded_route === 'boolean') {
         return use_preloaded_route;
       }
+    },
+
+    ws_servers: function(ws_servers, configuration) {
+      var idx, length, node_websocket_options,
+       sockets = [];
+
+      /* Allow defining ws_servers parameter as:
+       *  String: "host"
+       *  Array of Strings: ["host1", "host2"]
+       *  Array of Objects: [{ws_uri:"host1", weight:1}, {ws_uri:"host2", weight:0}]
+       *  Array of Objects and Strings: [{ws_uri:"host1"}, "host2"]
+       */
+      if (typeof ws_servers === 'string') {
+        ws_servers = [{ws_uri: ws_servers}];
+      } else if (Array.isArray(ws_servers) && ws_servers.length) {
+        length = ws_servers.length;
+        for (idx = 0; idx < length; idx++) {
+          if (typeof ws_servers[idx] === 'string') {
+            ws_servers[idx] = {ws_uri: ws_servers[idx]};
+          }
+        }
+      } else {
+        return;
+      }
+
+      node_websocket_options = UA.configuration_check.optional.node_websocket_options(configuration.node_websocket_options);
+
+      length = ws_servers.length;
+      for (idx = 0; idx < length; idx++) {
+        try {
+          sockets.push({
+            socket: new WebSocket(ws_servers[idx].ws_uri, node_websocket_options),
+            weight: ws_servers[idx].weight || 0
+          });
+        } catch(e) {
+          debugerror(e);
+          return;
+        }
+      }
+
+      return sockets;
     }
   }
 };
+
+/**
+ * Transport event handlers
+ */
+
+// Transport connecting event
+function onTransportConnecting(data) {
+  this.emit('connecting', data);
+}
+
+// Transport connected event.
+function onTransportConnect(data) {
+  if(this.status === C.STATUS_USER_CLOSED) {
+    return;
+  }
+
+  this.status = C.STATUS_READY;
+  this.error = null;
+
+  this.emit('connected', data);
+
+  if(this.dynConfiguration.register) {
+    this._registrator.register();
+  }
+}
+
+// Transport disconnected event.
+function onTransportDisconnect(data) {
+  // Run _onTransportError_ callback on every client transaction using _transport_
+  var type, idx, length,
+  client_transactions = ['nict', 'ict', 'nist', 'ist'];
+
+  length = client_transactions.length;
+  for (type = 0; type < length; type++) {
+    for(idx in this.transactions[client_transactions[type]]) {
+      this.transactions[client_transactions[type]][idx].onTransportError();
+    }
+  }
+
+  this.emit('disconnected', data);
+
+  // Call registrator _onTransportClosed_
+  this._registrator.onTransportClosed();
+
+  if (this.status !== C.STATUS_USER_CLOSED) {
+    this.status = C.STATUS_NOT_READY;
+    this.error = C.NETWORK_ERROR;
+  }
+}
+
+// Transport data event
+function onTransportData(data) {
+ var transaction,
+  transport = data.transport,
+  message = data.message;
+
+ message = Parser.parseMessage(message, this);
+
+ if (! message) {
+   return;
+ }
+
+ if (this.status === UA.C.STATUS_USER_CLOSED &&
+     message instanceof SIPMessage.IncomingRequest) {
+   return;
+ }
+
+ // Do some sanity check
+ if(! sanityCheck(message, this, transport)) {
+   return;
+ }
+
+ if(message instanceof SIPMessage.IncomingRequest) {
+   message.transport = transport;
+   this.receiveRequest(message);
+ } else if(message instanceof SIPMessage.IncomingResponse) {
+   /* Unike stated in 18.1.2, if a response does not match
+   * any transaction, it is discarded here and no passed to the core
+   * in order to be discarded there.
+   */
+   switch(message.method) {
+     case JsSIP_C.INVITE:
+       transaction = this.transactions.ict[message.via_branch];
+       if(transaction) {
+         transaction.receiveResponse(message);
+       }
+       break;
+     case JsSIP_C.ACK:
+       // Just in case ;-)
+       break;
+     default:
+       transaction = this.transactions.nict[message.via_branch];
+       if(transaction) {
+         transaction.receiveResponse(message);
+       }
+       break;
+   }
+ }
+}

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -23,6 +23,14 @@ Utils.isFunction = function(fn) {
   }
 };
 
+Utils.isString = function(str) {
+  if (str !== undefined) {
+    return (Object.prototype.toString.call(str) === '[object String]')? true : false;
+  } else {
+    return false;
+  }
+};
+
 Utils.isDecimal = function(num) {
   return !isNaN(num) && (parseFloat(num) === parseInt(num,10));
 };
@@ -31,6 +39,16 @@ Utils.isEmpty = function(value) {
   if (value === null || value === '' || value === undefined || (Array.isArray(value) && value.length === 0) || (typeof(value) === 'number' && isNaN(value))) {
     return true;
   }
+};
+
+Utils.hasMethods = function(obj /*, method list as strings */){
+  var i = 1, methodName;
+  while((methodName = arguments[i++])){
+    if(this.isFunction(obj[methodName])) {
+      return false;
+    }
+  }
+  return true;
 };
 
 Utils.createRandomToken = function(size, base) {

--- a/lib/WebSocket.js
+++ b/lib/WebSocket.js
@@ -1,0 +1,144 @@
+module.exports = WebSocket;
+
+/**
+ * Dependencies.
+ */
+var Grammar =     require('./Grammar');
+var debug =       require('debug')('JsSIP:WebSocket');
+var debugerror =  require('debug')('JsSIP:ERROR:WebSocket');
+
+// 'websocket' module uses the native WebSocket interface when bundled to run
+// in a browser.
+var W3CWebSocket = require('websocket').w3cwebsocket;
+
+function WebSocket(url, node_ws_options) {
+  debug('new()');
+
+  var sip_uri = null;
+  var via_transport = null;
+
+  this.ws = null;
+
+  this.node_ws_options = node_ws_options || {};
+
+  // setting the 'scheme' alters the sip_uri too (used in SIP Route header field)
+  Object.defineProperties(this, {
+    via_transport: {
+      get: function() { return via_transport; },
+      set: function(transport) {
+        via_transport = transport.toUpperCase();
+      }
+    },
+    sip_uri:  { get: function() { return sip_uri; }},
+    url:      { get: function() { return url; }}
+  });
+
+  var parsed_url = Grammar.parse(url, 'absoluteURI');
+
+  if(parsed_url === -1) {
+    debugerror('invalid WebSocket URI: ' + url);
+    throw new TypeError('Invalid argument: '+ url);
+  } else if(parsed_url.scheme !== 'wss' && parsed_url.scheme !== 'ws') {
+    debugerror('invalid WebSocket URI scheme: ' + parsed_url.scheme);
+    throw new TypeError('Invalid argument: '+ url);
+  } else {
+    sip_uri = '<sip:' + parsed_url.host +
+      (parsed_url.port ? ':' + parsed_url.port : '') + ';transport=ws;lr>';
+    this.via_transport = parsed_url.scheme;
+  }
+}
+
+WebSocket.prototype.connect = function () {
+  debug('connect()');
+
+  if (this.isConnected()) {
+    debug('WebSocket ' + this.url + ' is already connected');
+    return;
+  } else if (this.isConnecting()) {
+    debug('WebSocket ' + this.url + ' is connecting');
+    return;
+  }
+
+  if (this.ws) {
+    this.ws.close();
+  }
+
+  debug('connecting to WebSocket ' + this.url);
+
+  try {
+    this.ws = new W3CWebSocket(this.url, 'sip',
+        this.node_ws_options.origin,
+        this.node_ws_options.headers,
+        this.node_ws_options.requestOptions,
+        this.node_ws_options.clientConfig);
+
+    this.ws.binaryType = 'arraybuffer';
+
+    this.ws.onopen    = onOpen.bind(this);
+    this.ws.onclose   = onClose.bind(this);
+    this.ws.onmessage = onMessage.bind(this);
+    this.ws.onerror   = onError.bind(this);
+  } catch(e) {
+    onError.call(this, e);
+  }
+};
+
+WebSocket.prototype.disconnect = function() {
+  debug('disconnect()');
+
+  if (this.ws) {
+    this.ws.close();
+    this.ws = null;
+  }
+};
+
+WebSocket.prototype.send = function(message) {
+  debug('send()');
+
+  if (this.isConnected) {
+    this.ws.send(message);
+    return true;
+  } else {
+    debugerror('unable to send message, WebSocket is not open');
+    return false;
+  }
+};
+
+WebSocket.prototype.isConnected = function() {
+  return this.ws && this.ws.readyState === this.ws.OPEN;
+};
+
+WebSocket.prototype.isConnecting = function() {
+  return this.ws && this.ws.readyState === this.ws.CONNECTING;
+};
+
+
+/**
+ * WebSocket Event Handlers
+ */
+
+function onOpen() {
+  debug('WebSocket ' + this.url + ' connected');
+
+  this.onconnect();
+}
+
+function onClose(e) {
+  debug('WebSocket ' + this.url + ' closed');
+
+  if (e.wasClean === false) {
+    debug('WebSocket abrupt disconnection');
+  }
+
+  this.ondisconnect(e.wasClean, e.code, e.reason);
+}
+
+function onMessage(e) {
+  debug('received WebSocket message');
+
+  this.ondata(e.data);
+}
+
+function onError(e) {
+  debugerror('WebSocket ' + this.url + ' error: '+ e);
+}

--- a/test/include/testUA.js
+++ b/test/include/testUA.js
@@ -23,23 +23,32 @@ module.exports = {
   UA_CONFIGURATION_AFTER_START: {
     uri: 'sip:fakeUA@jssip.net',
     password: '1234ññññ',
-    ws_servers: [{'ws_uri':'ws://localhost:12345','sip_uri':'<sip:localhost:12345;transport=ws;lr>','weight':0,'status':0,'scheme':'WS'}],
     display_name: 'Fake UA ð→€ł !!!',
     authorization_user: 'fakeUA',
     instance_id: '8f1fa16a-1165-4a96-8341-785b1ef24f12',  // Without 'uuid:'.
     registrar_server: 'sip:registrar.jssip.net:6060;transport=tcp',
     register_expires: 600,
     register: false,
-    connection_recovery_min_interval: 2,
-    connection_recovery_max_interval: 30,
     use_preloaded_route: true,
     no_answer_timeout: 60000 * 1000,  // Internally converted to miliseconds.
     session_timers: true,
-    hack_via_tcp: false,
-    hack_via_ws: true,
     hack_ip_in_contact: false
-  }
+  },
 
+  UA_TRANSPORT_AFTER_START: {
+    'sockets': [{
+      'socket': {
+        'via_transport':'WS',
+        'sip_uri':'<sip:localhost:12345;transport=ws;lr>',
+        'url':'ws://localhost:12345'
+      },
+      'weight':0
+    }],
+    'recovery_options': {
+      'min_interval': 2,
+      'max_interval': 30
+    }
+  }
 };
 
 

--- a/test/test-UA-no-WebRTC.js
+++ b/test/test-UA-no-WebRTC.js
@@ -40,6 +40,18 @@ module.exports = {
       }
     }
 
+    var transport = testUA.UA_TRANSPORT_AFTER_START;
+    var sockets = transport.sockets;
+    var socket = sockets[0].socket;
+
+    test.deepEqual(sockets.length, ua.transport.sockets.length, 'testing transport sockets number');
+    test.deepEqual(sockets[0].weight, ua.transport.sockets[0].weight, 'testing sockets weight');
+    test.deepEqual(socket.via_transport, ua.transport.via_transport, 'testing transport via_transport');
+    test.deepEqual(socket.sip_uri, ua.transport.sip_uri, 'testing transport sip_uri');
+    test.deepEqual(socket.url, ua.transport.url, 'testing transport url');
+
+    test.deepEqual(transport.recovery_options, ua.transport.recovery_options, 'testing transport recovery_options');
+
     ua.sendMessage('test', 'FAIL WITH CONNECTION_ERROR PLEASE', {
       eventHandlers: {
         failed: function(e) {


### PR DESCRIPTION
Make JsSIP socket agnostic.

The new JsSIP.Socket interface abstracts JsSIP from the mechanism used to send
and receive SIP traffic. JsSIP internal transport deals now with this interface
and hence, it is not attached to use the built-in WebSocket.

A new configuration parameter 'sockets' allows the user to provide it's own
sockets, which must implement the JsSIP.Socket interface.

The internal transport management and recovery handling has been
rewriten, leveraging the UA from any transport logic.

'hack_via_tcp' and 'hack_via_ws' configuration parameters have been removed.
The Via transport parameter is now seteable per Socket (see via_transport
Socket parameter).