### PR TITLE
Clean up trailing whitespace in built lib/Grammar.js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -92,6 +92,7 @@ gulp.task('grammar', function(cb) {
 
 			var grammar = fs.readFileSync('lib/Grammar.js').toString();
 			var modified_grammar = grammar.replace(/throw new this\.SyntaxError\(([\s\S]*?)\);([\s\S]*?)}([\s\S]*?)return result;/, 'new this.SyntaxError($1);\n        return -1;$2}$3return data;');
+			modified_grammar = modified_grammar.replace(/\s+$/mg, '');
 			fs.writeFileSync('lib/Grammar.js', modified_grammar);
 			gutil.log('grammar: ' + gutil.colors.yellow('done'));
 			cb();

--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -4,7 +4,6 @@ module.exports = (function(){
    *
    * http://pegjs.majda.cz/
    */
-  
   function quote(s) {
     /*
      * ECMA-262, 5th ed., 7.8.4: All characters may appear literally in a
@@ -27,7 +26,6 @@ module.exports = (function(){
       .replace(/[\x00-\x07\x0B\x0E-\x1F\x80-\uFFFF]/g, escape)
       + '"';
   }
-  
   var result = {
     /*
      * Parses the input with a generated parser. If the parsing is successfull,
@@ -263,7 +261,6 @@ module.exports = (function(){
         "from_tag": parse_from_tag,
         "early_flag": parse_early_flag
       };
-      
       if (startRule !== undefined) {
         if (parseFunctions[startRule] === undefined) {
           throw new Error("Invalid rule name: " + quote(startRule) + ".");
@@ -271,28 +268,22 @@ module.exports = (function(){
       } else {
         startRule = "CRLF";
       }
-      
       var pos = 0;
       var reportFailures = 0;
       var rightmostFailuresPos = 0;
       var rightmostFailuresExpected = [];
-      
       function padLeft(input, padding, length) {
         var result = input;
-        
         var padLength = length - input.length;
         for (var i = 0; i < padLength; i++) {
           result = padding + result;
         }
-        
         return result;
       }
-      
       function escape(ch) {
         var charCode = ch.charCodeAt(0);
         var escapeChar;
         var length;
-        
         if (charCode <= 0xFF) {
           escapeChar = 'x';
           length = 2;
@@ -300,26 +291,20 @@ module.exports = (function(){
           escapeChar = 'u';
           length = 4;
         }
-        
         return '\\' + escapeChar + padLeft(charCode.toString(16).toUpperCase(), '0', length);
       }
-      
       function matchFailed(failure) {
         if (pos < rightmostFailuresPos) {
           return;
         }
-        
         if (pos > rightmostFailuresPos) {
           rightmostFailuresPos = pos;
           rightmostFailuresExpected = [];
         }
-        
         rightmostFailuresExpected.push(failure);
       }
-      
       function parse_CRLF() {
         var result0;
-        
         if (input.substr(pos, 2) === "\r\n") {
           result0 = "\r\n";
           pos += 2;
@@ -331,10 +316,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_DIGIT() {
         var result0;
-        
         if (/^[0-9]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -346,10 +329,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ALPHA() {
         var result0;
-        
         if (/^[a-zA-Z]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -361,10 +342,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_HEXDIG() {
         var result0;
-        
         if (/^[0-9a-fA-F]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -376,20 +355,16 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_WSP() {
         var result0;
-        
         result0 = parse_SP();
         if (result0 === null) {
           result0 = parse_HTAB();
         }
         return result0;
       }
-      
       function parse_OCTET() {
         var result0;
-        
         if (/^[\0-\xFF]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -401,10 +376,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_DQUOTE() {
         var result0;
-        
         if (/^["]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -416,10 +389,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SP() {
         var result0;
-        
         if (input.charCodeAt(pos) === 32) {
           result0 = " ";
           pos++;
@@ -431,10 +402,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_HTAB() {
         var result0;
-        
         if (input.charCodeAt(pos) === 9) {
           result0 = "\t";
           pos++;
@@ -446,10 +415,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_alphanum() {
         var result0;
-        
         if (/^[a-zA-Z0-9]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -461,10 +428,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_reserved() {
         var result0;
-        
         if (input.charCodeAt(pos) === 59) {
           result0 = ";";
           pos++;
@@ -575,20 +540,16 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_unreserved() {
         var result0;
-        
         result0 = parse_alphanum();
         if (result0 === null) {
           result0 = parse_mark();
         }
         return result0;
       }
-      
       function parse_mark() {
         var result0;
-        
         if (input.charCodeAt(pos) === 45) {
           result0 = "-";
           pos++;
@@ -688,11 +649,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_escaped() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 37) {
@@ -730,11 +689,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_LWS() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         pos2 = pos;
@@ -786,19 +743,15 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SWS() {
         var result0;
-        
         result0 = parse_LWS();
         result0 = result0 !== null ? result0 : "";
         return result0;
       }
-      
       function parse_HCOLON() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = [];
@@ -847,11 +800,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_TEXT_UTF8_TRIM() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result1 = parse_TEXT_UTF8char();
@@ -926,10 +877,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_TEXT_UTF8char() {
         var result0;
-        
         if (/^[!-~]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -944,10 +893,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_UTF8_NONASCII() {
         var result0;
-        
         if (/^[\x80-\uFFFF]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -959,10 +906,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_UTF8_CONT() {
         var result0;
-        
         if (/^[\x80-\xBF]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -974,10 +919,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_LHEX() {
         var result0;
-        
         result0 = parse_DIGIT();
         if (result0 === null) {
           if (/^[a-f]/.test(input.charAt(pos))) {
@@ -992,11 +935,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_token() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_alphanum();
         if (result1 === null) {
@@ -1237,11 +1178,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_token_nodot() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_alphanum();
         if (result1 === null) {
@@ -1460,10 +1399,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_separators() {
         var result0;
-        
         if (input.charCodeAt(pos) === 40) {
           result0 = "(";
           pos++;
@@ -1649,11 +1586,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_word() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_alphanum();
         if (result1 === null) {
@@ -2164,11 +2099,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_STAR() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2206,11 +2139,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SLASH() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2248,11 +2179,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_EQUAL() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2290,11 +2219,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_LPAREN() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2332,11 +2259,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_RPAREN() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2374,11 +2299,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_RAQUOT() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 62) {
@@ -2410,11 +2333,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_LAQUOT() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2446,11 +2367,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_COMMA() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2488,11 +2407,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SEMI() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2530,11 +2447,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_COLON() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2572,11 +2487,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_LDQUOT() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2600,11 +2513,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_RDQUOT() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_DQUOTE();
@@ -2628,11 +2539,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_comment() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_LPAREN();
         if (result0 !== null) {
@@ -2672,10 +2581,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ctext() {
         var result0;
-        
         if (/^[!-']/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
@@ -2715,11 +2622,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_quoted_string() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2767,11 +2672,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_quoted_string_clean() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SWS();
@@ -2819,10 +2722,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_qdtext() {
         var result0;
-        
         result0 = parse_LWS();
         if (result0 === null) {
           if (input.charCodeAt(pos) === 33) {
@@ -2862,11 +2763,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_quoted_pair() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         if (input.charCodeAt(pos) === 92) {
           result0 = "\\";
@@ -2921,11 +2820,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SIP_URI_noparams() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_uri_scheme();
@@ -2980,11 +2877,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SIP_URI() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_uri_scheme();
@@ -3045,7 +2940,6 @@ module.exports = (function(){
                                 delete data.host_type;
                                 delete data.port;
                                 delete data.uri_params;
-        
                                 if (startRule === 'SIP_URI') { data = data.uri;}
                               } catch(e) {
                                 data = -1;
@@ -3056,21 +2950,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uri_scheme() {
         var result0;
-        
         result0 = parse_uri_scheme_sips();
         if (result0 === null) {
           result0 = parse_uri_scheme_sip();
         }
         return result0;
       }
-      
       function parse_uri_scheme_sips() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 4).toLowerCase() === "sips") {
           result0 = input.substr(pos, 4);
@@ -3090,11 +2980,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uri_scheme_sip() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 3).toLowerCase() === "sip") {
           result0 = input.substr(pos, 3);
@@ -3114,11 +3002,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_userinfo() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_user();
@@ -3179,10 +3065,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_user() {
         var result0, result1;
-        
         result1 = parse_unreserved();
         if (result1 === null) {
           result1 = parse_escaped();
@@ -3207,10 +3091,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_user_unreserved() {
         var result0;
-        
         if (input.charCodeAt(pos) === 38) {
           result0 = "&";
           pos++;
@@ -3299,11 +3181,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_password() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result0 = [];
         result1 = parse_unreserved();
@@ -3436,11 +3316,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hostport() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_host();
         if (result0 !== null) {
@@ -3479,11 +3357,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_host() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_hostname();
         if (result0 === null) {
@@ -3502,11 +3378,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hostname() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = [];
@@ -3594,11 +3468,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_domainlabel() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_alphanum();
         if (result0 !== null) {
@@ -3664,11 +3536,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_toplabel() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_ALPHA();
         if (result0 !== null) {
@@ -3734,11 +3604,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_IPv6reference() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 91) {
@@ -3786,11 +3654,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_IPv6address() {
         var result0, result1, result2, result3, result4, result5, result6, result7, result8, result9, result10, result11, result12;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_h16();
@@ -5390,11 +5256,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_h16() {
         var result0, result1, result2, result3;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_HEXDIG();
         if (result0 !== null) {
@@ -5426,11 +5290,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ls32() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_h16();
         if (result0 !== null) {
@@ -5464,11 +5326,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_IPv4address() {
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_dec_octet();
@@ -5548,11 +5408,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_dec_octet() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 2) === "25") {
           result0 = "25";
@@ -5680,11 +5538,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_port() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_DIGIT();
@@ -5734,11 +5590,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uri_parameters() {
         var result0, result1, result2;
         var pos0;
-        
         result0 = [];
         pos0 = pos;
         if (input.charCodeAt(pos) === 59) {
@@ -5789,10 +5643,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uri_parameter() {
         var result0;
-        
         result0 = parse_transport_param();
         if (result0 === null) {
           result0 = parse_user_param();
@@ -5814,11 +5666,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_transport_param() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 10).toLowerCase() === "transport=") {
@@ -5896,11 +5746,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_user_param() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 5).toLowerCase() === "user=") {
@@ -5956,11 +5804,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_method_param() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 7).toLowerCase() === "method=") {
@@ -5994,11 +5840,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ttl_param() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 4).toLowerCase() === "ttl=") {
@@ -6032,11 +5876,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_maddr_param() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 6).toLowerCase() === "maddr=") {
@@ -6070,11 +5912,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_lr_param() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 2).toLowerCase() === "lr") {
@@ -6130,11 +5970,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_other_param() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_pname();
@@ -6188,11 +6026,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_pname() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_paramchar();
         if (result1 !== null) {
@@ -6212,11 +6048,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_pvalue() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_paramchar();
         if (result1 !== null) {
@@ -6236,10 +6070,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_paramchar() {
         var result0;
-        
         result0 = parse_param_unreserved();
         if (result0 === null) {
           result0 = parse_unreserved();
@@ -6249,10 +6081,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_param_unreserved() {
         var result0;
-        
         if (input.charCodeAt(pos) === 91) {
           result0 = "[";
           pos++;
@@ -6330,11 +6160,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_headers() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1;
-        
         pos0 = pos;
         if (input.charCodeAt(pos) === 63) {
           result0 = "?";
@@ -6412,11 +6240,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_header() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_hname();
@@ -6462,10 +6288,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hname() {
         var result0, result1;
-        
         result1 = parse_hnv_unreserved();
         if (result1 === null) {
           result1 = parse_unreserved();
@@ -6490,10 +6314,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hvalue() {
         var result0, result1;
-        
         result0 = [];
         result1 = parse_hnv_unreserved();
         if (result1 === null) {
@@ -6514,10 +6336,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hnv_unreserved() {
         var result0;
-        
         if (input.charCodeAt(pos) === 91) {
           result0 = "[";
           pos++;
@@ -6595,21 +6415,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Request_Response() {
         var result0;
-        
         result0 = parse_Status_Line();
         if (result0 === null) {
           result0 = parse_Request_Line();
         }
         return result0;
       }
-      
       function parse_Request_Line() {
         var result0, result1, result2, result3, result4;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_Method();
         if (result0 !== null) {
@@ -6644,21 +6460,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Request_URI() {
         var result0;
-        
         result0 = parse_SIP_URI();
         if (result0 === null) {
           result0 = parse_absoluteURI();
         }
         return result0;
       }
-      
       function parse_absoluteURI() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_scheme();
         if (result0 !== null) {
@@ -6692,11 +6504,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hier_part() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_net_path();
         if (result0 === null) {
@@ -6738,11 +6548,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_net_path() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 2) === "//") {
           result0 = "//";
@@ -6774,11 +6582,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_abs_path() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         if (input.charCodeAt(pos) === 47) {
           result0 = "/";
@@ -6803,11 +6609,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_opaque_part() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_uric_no_slash();
         if (result0 !== null) {
@@ -6829,10 +6633,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uric() {
         var result0;
-        
         result0 = parse_reserved();
         if (result0 === null) {
           result0 = parse_unreserved();
@@ -6842,10 +6644,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uric_no_slash() {
         var result0;
-        
         result0 = parse_unreserved();
         if (result0 === null) {
           result0 = parse_escaped();
@@ -6951,11 +6751,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_path_segments() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_segment();
         if (result0 !== null) {
@@ -7019,11 +6817,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_segment() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = [];
         result1 = parse_pchar();
@@ -7092,10 +6888,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_param() {
         var result0, result1;
-        
         result0 = [];
         result1 = parse_pchar();
         while (result1 !== null) {
@@ -7104,10 +6898,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_pchar() {
         var result0;
-        
         result0 = parse_unreserved();
         if (result0 === null) {
           result0 = parse_escaped();
@@ -7191,11 +6983,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_scheme() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_ALPHA();
@@ -7297,21 +7087,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_authority() {
         var result0;
-        
         result0 = parse_srvr();
         if (result0 === null) {
           result0 = parse_reg_name();
         }
         return result0;
       }
-      
       function parse_srvr() {
         var result0, result1;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_userinfo();
@@ -7351,10 +7137,8 @@ module.exports = (function(){
         result0 = result0 !== null ? result0 : "";
         return result0;
       }
-      
       function parse_reg_name() {
         var result0, result1;
-        
         result1 = parse_unreserved();
         if (result1 === null) {
           result1 = parse_escaped();
@@ -7549,10 +7333,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_query() {
         var result0, result1;
-        
         result0 = [];
         result1 = parse_uric();
         while (result1 !== null) {
@@ -7561,11 +7343,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SIP_Version() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 3).toLowerCase() === "sip") {
@@ -7650,10 +7430,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_INVITEm() {
         var result0;
-        
         if (input.substr(pos, 6) === "INVITE") {
           result0 = "INVITE";
           pos += 6;
@@ -7665,10 +7443,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ACKm() {
         var result0;
-        
         if (input.substr(pos, 3) === "ACK") {
           result0 = "ACK";
           pos += 3;
@@ -7680,10 +7456,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_OPTIONSm() {
         var result0;
-        
         if (input.substr(pos, 7) === "OPTIONS") {
           result0 = "OPTIONS";
           pos += 7;
@@ -7695,10 +7469,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_BYEm() {
         var result0;
-        
         if (input.substr(pos, 3) === "BYE") {
           result0 = "BYE";
           pos += 3;
@@ -7710,10 +7482,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_CANCELm() {
         var result0;
-        
         if (input.substr(pos, 6) === "CANCEL") {
           result0 = "CANCEL";
           pos += 6;
@@ -7725,10 +7495,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_REGISTERm() {
         var result0;
-        
         if (input.substr(pos, 8) === "REGISTER") {
           result0 = "REGISTER";
           pos += 8;
@@ -7740,10 +7508,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_SUBSCRIBEm() {
         var result0;
-        
         if (input.substr(pos, 9) === "SUBSCRIBE") {
           result0 = "SUBSCRIBE";
           pos += 9;
@@ -7755,10 +7521,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_NOTIFYm() {
         var result0;
-        
         if (input.substr(pos, 6) === "NOTIFY") {
           result0 = "NOTIFY";
           pos += 6;
@@ -7770,10 +7534,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_REFERm() {
         var result0;
-        
         if (input.substr(pos, 5) === "REFER") {
           result0 = "REFER";
           pos += 5;
@@ -7785,11 +7547,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Method() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_INVITEm();
         if (result0 === null) {
@@ -7829,11 +7589,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Status_Line() {
         var result0, result1, result2, result3, result4;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_SIP_Version();
         if (result0 !== null) {
@@ -7868,11 +7626,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Status_Code() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_extension_code();
         if (result0 !== null) {
@@ -7884,11 +7640,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_extension_code() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_DIGIT();
         if (result0 !== null) {
@@ -7911,11 +7665,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Reason_Phrase() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result0 = [];
         result1 = parse_reserved();
@@ -7968,11 +7720,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Allow_Events() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_event_type();
         if (result0 !== null) {
@@ -8020,11 +7770,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Call_ID() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_word();
@@ -8071,11 +7819,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Contact() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         result0 = parse_STAR();
         if (result0 === null) {
@@ -8146,11 +7892,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_contact_param() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SIP_URI_noparams();
@@ -8222,11 +7966,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_name_addr() {
         var result0, result1, result2, result3;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_display_name();
         result0 = result0 !== null ? result0 : "";
@@ -8256,11 +7998,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_display_name() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_token();
@@ -8323,10 +8063,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_contact_params() {
         var result0;
-        
         result0 = parse_c_p_q();
         if (result0 === null) {
           result0 = parse_c_p_expires();
@@ -8336,11 +8074,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_c_p_q() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 1).toLowerCase() === "q") {
@@ -8380,11 +8116,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_c_p_expires() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 7).toLowerCase() === "expires") {
@@ -8424,11 +8158,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_delta_seconds() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_DIGIT();
         if (result1 !== null) {
@@ -8449,11 +8181,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_qvalue() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.charCodeAt(pos) === 48) {
@@ -8523,11 +8253,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_generic_param() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_token();
@@ -8573,10 +8301,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_gen_value() {
         var result0;
-        
         result0 = parse_token();
         if (result0 === null) {
           result0 = parse_host();
@@ -8586,11 +8312,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Content_Disposition() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_disp_type();
         if (result0 !== null) {
@@ -8638,10 +8362,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_disp_type() {
         var result0;
-        
         if (input.substr(pos, 6).toLowerCase() === "render") {
           result0 = input.substr(pos, 6);
           pos += 6;
@@ -8689,21 +8411,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_disp_param() {
         var result0;
-        
         result0 = parse_handling_param();
         if (result0 === null) {
           result0 = parse_generic_param();
         }
         return result0;
       }
-      
       function parse_handling_param() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 8).toLowerCase() === "handling") {
           result0 = input.substr(pos, 8);
@@ -8756,11 +8474,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Content_Encoding() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -8808,11 +8524,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Content_Length() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_DIGIT();
         if (result1 !== null) {
@@ -8833,11 +8547,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Content_Type() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_media_type();
         if (result0 !== null) {
@@ -8849,11 +8561,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_media_type() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_m_type();
         if (result0 !== null) {
@@ -8913,20 +8623,16 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_m_type() {
         var result0;
-        
         result0 = parse_discrete_type();
         if (result0 === null) {
           result0 = parse_composite_type();
         }
         return result0;
       }
-      
       function parse_discrete_type() {
         var result0;
-        
         if (input.substr(pos, 4).toLowerCase() === "text") {
           result0 = input.substr(pos, 4);
           pos += 4;
@@ -8985,10 +8691,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_composite_type() {
         var result0;
-        
         if (input.substr(pos, 7).toLowerCase() === "message") {
           result0 = input.substr(pos, 7);
           pos += 7;
@@ -9014,21 +8718,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_extension_token() {
         var result0;
-        
         result0 = parse_token();
         if (result0 === null) {
           result0 = parse_x_token();
         }
         return result0;
       }
-      
       function parse_x_token() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 2).toLowerCase() === "x-") {
           result0 = input.substr(pos, 2);
@@ -9053,21 +8753,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_m_subtype() {
         var result0;
-        
         result0 = parse_extension_token();
         if (result0 === null) {
           result0 = parse_token();
         }
         return result0;
       }
-      
       function parse_m_parameter() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -9090,21 +8786,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_m_value() {
         var result0;
-        
         result0 = parse_token();
         if (result0 === null) {
           result0 = parse_quoted_string();
         }
         return result0;
       }
-      
       function parse_CSeq() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_CSeq_value();
         if (result0 !== null) {
@@ -9127,11 +8819,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_CSeq_value() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_DIGIT();
         if (result1 !== null) {
@@ -9152,11 +8842,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Expires() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_delta_seconds();
         if (result0 !== null) {
@@ -9167,11 +8855,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Event() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_event_type();
@@ -9227,11 +8913,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_event_type() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token_nodot();
         if (result0 !== null) {
@@ -9295,11 +8979,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_From() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SIP_URI_noparams();
@@ -9364,21 +9046,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_from_param() {
         var result0;
-        
         result0 = parse_tag_param();
         if (result0 === null) {
           result0 = parse_generic_param();
         }
         return result0;
       }
-      
       function parse_tag_param() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 3).toLowerCase() === "tag") {
@@ -9416,11 +9094,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Max_Forwards() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result1 = parse_DIGIT();
         if (result1 !== null) {
@@ -9441,11 +9117,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Min_Expires() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_delta_seconds();
         if (result0 !== null) {
@@ -9456,11 +9130,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Name_Addr_Header() {
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = [];
@@ -9543,18 +9215,14 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Proxy_Authenticate() {
         var result0;
-        
         result0 = parse_challenge();
         return result0;
       }
-      
       function parse_challenge() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         if (input.substr(pos, 6).toLowerCase() === "digest") {
           result0 = input.substr(pos, 6);
@@ -9625,11 +9293,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_other_challenge() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -9689,11 +9355,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_auth_param() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -9719,10 +9383,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_digest_cln() {
         var result0;
-        
         result0 = parse_realm();
         if (result0 === null) {
           result0 = parse_domain();
@@ -9747,11 +9409,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_realm() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 5).toLowerCase() === "realm") {
           result0 = input.substr(pos, 5);
@@ -9782,11 +9442,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_realm_value() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_quoted_string_clean();
         if (result0 !== null) {
@@ -9797,11 +9455,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_domain() {
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1;
-        
         pos0 = pos;
         if (input.substr(pos, 6).toLowerCase() === "domain") {
           result0 = input.substr(pos, 6);
@@ -9899,21 +9555,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_URI() {
         var result0;
-        
         result0 = parse_absoluteURI();
         if (result0 === null) {
           result0 = parse_abs_path();
         }
         return result0;
       }
-      
       function parse_nonce() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 5).toLowerCase() === "nonce") {
           result0 = input.substr(pos, 5);
@@ -9944,11 +9596,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_nonce_value() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_quoted_string_clean();
         if (result0 !== null) {
@@ -9959,11 +9609,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_opaque() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 6).toLowerCase() === "opaque") {
@@ -10001,11 +9649,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_stale() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         if (input.substr(pos, 5).toLowerCase() === "stale") {
           result0 = input.substr(pos, 5);
@@ -10069,11 +9715,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_algorithm() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 9).toLowerCase() === "algorithm") {
@@ -10134,11 +9778,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_qop_options() {
         var result0, result1, result2, result3, result4, result5, result6;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         if (input.substr(pos, 3).toLowerCase() === "qop") {
           result0 = input.substr(pos, 3);
@@ -10241,11 +9883,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_qop_value() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 8).toLowerCase() === "auth-int") {
           result0 = input.substr(pos, 8);
@@ -10280,11 +9920,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Proxy_Require() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -10332,11 +9970,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Record_Route() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_rec_route();
@@ -10404,11 +10040,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_rec_route() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_name_addr();
@@ -10477,11 +10111,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Reason() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 3).toLowerCase() === "sip") {
@@ -10542,9 +10174,7 @@ module.exports = (function(){
         if (result0 !== null) {
           result0 = (function(offset, protocol) {
                           data.protocol = protocol.toLowerCase();
-        
                           if (!data.params) data.params = {};
-        
                           if (data.params.text && data.params.text[0] === '"') {
                             var text = data.params.text;
                             data.text = text.substring(1, text.length-1);
@@ -10557,21 +10187,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_reason_param() {
         var result0;
-        
         result0 = parse_reason_cause();
         if (result0 === null) {
           result0 = parse_generic_param();
         }
         return result0;
       }
-      
       function parse_reason_cause() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 5).toLowerCase() === "cause") {
@@ -10620,11 +10246,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Require() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -10672,11 +10296,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Route() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_route_param();
         if (result0 !== null) {
@@ -10724,11 +10346,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_route_param() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_name_addr();
         if (result0 !== null) {
@@ -10776,11 +10396,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Subscription_State() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_substate_value();
         if (result0 !== null) {
@@ -10828,11 +10446,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_substate_value() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 6).toLowerCase() === "active") {
           result0 = input.substr(pos, 6);
@@ -10877,11 +10493,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_subexp_params() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 6).toLowerCase() === "reason") {
@@ -10999,10 +10613,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_event_reason_value() {
         var result0;
-        
         if (input.substr(pos, 11).toLowerCase() === "deactivated") {
           result0 = input.substr(pos, 11);
           pos += 11;
@@ -11083,19 +10695,15 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Subject() {
         var result0;
-        
         result0 = parse_TEXT_UTF8_TRIM();
         result0 = result0 !== null ? result0 : "";
         return result0;
       }
-      
       function parse_Supported() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -11144,11 +10752,9 @@ module.exports = (function(){
         result0 = result0 !== null ? result0 : "";
         return result0;
       }
-      
       function parse_To() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SIP_URI_noparams();
@@ -11213,21 +10819,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_to_param() {
         var result0;
-        
         result0 = parse_tag_param();
         if (result0 === null) {
           result0 = parse_generic_param();
         }
         return result0;
       }
-      
       function parse_Via() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_via_param();
         if (result0 !== null) {
@@ -11275,11 +10877,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_param() {
         var result0, result1, result2, result3, result4, result5;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_sent_protocol();
         if (result0 !== null) {
@@ -11339,10 +10939,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_params() {
         var result0;
-        
         result0 = parse_via_ttl();
         if (result0 === null) {
           result0 = parse_via_maddr();
@@ -11361,11 +10959,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_ttl() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 3).toLowerCase() === "ttl") {
@@ -11404,11 +11000,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_maddr() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 5).toLowerCase() === "maddr") {
@@ -11447,11 +11041,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_received() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 8).toLowerCase() === "received") {
@@ -11493,11 +11085,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_branch() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 6).toLowerCase() === "branch") {
@@ -11536,11 +11126,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_response_port() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 5).toLowerCase() === "rport") {
@@ -11593,11 +11181,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_sent_protocol() {
         var result0, result1, result2, result3, result4;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_protocol_name();
         if (result0 !== null) {
@@ -11632,11 +11218,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_protocol_name() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 3).toLowerCase() === "sip") {
           result0 = input.substr(pos, 3);
@@ -11659,11 +11243,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_transport() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 3).toLowerCase() === "udp") {
           result0 = input.substr(pos, 3);
@@ -11719,11 +11301,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_sent_by() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_via_host();
         if (result0 !== null) {
@@ -11754,11 +11334,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_host() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_IPv4address();
         if (result0 === null) {
@@ -11776,11 +11354,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_via_port() {
         var result0, result1, result2, result3, result4;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_DIGIT();
@@ -11828,11 +11404,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_ttl() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_DIGIT();
@@ -11865,18 +11439,14 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_WWW_Authenticate() {
         var result0;
-        
         result0 = parse_challenge();
         return result0;
       }
-      
       function parse_Session_Expires() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_s_e_expires();
         if (result0 !== null) {
@@ -11924,11 +11494,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_s_e_expires() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_delta_seconds();
         if (result0 !== null) {
@@ -11939,21 +11507,17 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_s_e_params() {
         var result0;
-        
         result0 = parse_s_e_refresher();
         if (result0 === null) {
           result0 = parse_generic_param();
         }
         return result0;
       }
-      
       function parse_s_e_refresher() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 9).toLowerCase() === "refresher") {
@@ -12010,11 +11574,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_extension_header() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_token();
         if (result0 !== null) {
@@ -12037,10 +11599,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_header_value() {
         var result0, result1;
-        
         result0 = [];
         result1 = parse_TEXT_UTF8char();
         if (result1 === null) {
@@ -12061,10 +11621,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_message_body() {
         var result0, result1;
-        
         result0 = [];
         result1 = parse_OCTET();
         while (result1 !== null) {
@@ -12073,11 +11631,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uuid_URI() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 5) === "uuid:") {
           result0 = "uuid:";
@@ -12102,11 +11658,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_uuid() {
         var result0, result1, result2, result3, result4, result5, result6, result7, result8;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_hex8();
@@ -12205,11 +11759,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hex4() {
         var result0, result1, result2, result3;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_HEXDIG();
         if (result0 !== null) {
@@ -12238,11 +11790,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hex8() {
         var result0, result1;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_hex4();
         if (result0 !== null) {
@@ -12259,11 +11809,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_hex12() {
         var result0, result1, result2;
         var pos0;
-        
         pos0 = pos;
         result0 = parse_hex4();
         if (result0 !== null) {
@@ -12286,11 +11834,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Refer_To() {
         var result0, result1, result2, result3;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_SIP_URI_noparams();
@@ -12353,11 +11899,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_Replaces() {
         var result0, result1, result2, result3;
         var pos0, pos1;
-        
         pos0 = pos;
         result0 = parse_call_id();
         if (result0 !== null) {
@@ -12405,11 +11949,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_call_id() {
         var result0, result1, result2;
         var pos0, pos1, pos2;
-        
         pos0 = pos;
         pos1 = pos;
         result0 = parse_word();
@@ -12456,10 +11998,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_replaces_param() {
         var result0;
-        
         result0 = parse_to_tag();
         if (result0 === null) {
           result0 = parse_from_tag();
@@ -12472,11 +12012,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_to_tag() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 6) === "to-tag") {
@@ -12515,11 +12053,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_from_tag() {
         var result0, result1, result2;
         var pos0, pos1;
-        
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 8) === "from-tag") {
@@ -12558,11 +12094,9 @@ module.exports = (function(){
         }
         return result0;
       }
-      
       function parse_early_flag() {
         var result0;
         var pos0;
-        
         pos0 = pos;
         if (input.substr(pos, 10) === "early-only") {
           result0 = "early-only";
@@ -12582,11 +12116,8 @@ module.exports = (function(){
         }
         return result0;
       }
-      
-      
       function cleanupExpected(expected) {
         expected.sort();
-        
         var lastExpected = null;
         var cleanExpected = [];
         for (var i = 0; i < expected.length; i++) {
@@ -12597,7 +12128,6 @@ module.exports = (function(){
         }
         return cleanExpected;
       }
-      
       function computeErrorPosition() {
         /*
          * The first idea was to use |String.split| to break the input up to the
@@ -12605,11 +12135,9 @@ module.exports = (function(){
          * there. However IE's |split| implementation is so broken that it was
          * enough to prevent it.
          */
-        
         var line = 1;
         var column = 1;
         var seenCR = false;
-        
         for (var i = 0; i < Math.max(pos, rightmostFailuresPos); i++) {
           var ch = input.charAt(i);
           if (ch === "\n") {
@@ -12625,19 +12153,12 @@ module.exports = (function(){
             seenCR = false;
           }
         }
-        
         return { line: line, column: column };
       }
-      
-      
         var URI = require('./URI');
         var NameAddrHeader = require('./NameAddrHeader');
-      
         var data = {};
-      
-      
       var result = parseFunctions[startRule]();
-      
       /*
        * The parser is now in one of the following three states:
        *
@@ -12666,7 +12187,6 @@ module.exports = (function(){
         var offset = Math.max(pos, rightmostFailuresPos);
         var found = offset < input.length ? input.charAt(offset) : null;
         var errorPosition = computeErrorPosition();
-        
         new this.SyntaxError(
           cleanupExpected(rightmostFailuresExpected),
           found,
@@ -12676,20 +12196,15 @@ module.exports = (function(){
         );
         return -1;
       }
-      
       return data;
     },
-    
     /* Returns the parser source code. */
     toSource: function() { return this._source; }
   };
-  
   /* Thrown when a parser encounters a syntax error. */
-  
   result.SyntaxError = function(expected, found, offset, line, column) {
     function buildMessage(expected, found) {
       var expectedHumanized, foundHumanized;
-      
       switch (expected.length) {
         case 0:
           expectedHumanized = "end of input";
@@ -12702,12 +12217,9 @@ module.exports = (function(){
             + " or "
             + expected[expected.length - 1];
       }
-      
       foundHumanized = found ? quote(found) : "end of input";
-      
       return "Expected " + expectedHumanized + " but " + foundHumanized + " found.";
     }
-    
     this.name = "SyntaxError";
     this.expected = expected;
     this.found = found;
@@ -12716,8 +12228,6 @@ module.exports = (function(){
     this.line = line;
     this.column = column;
   };
-  
   result.SyntaxError.prototype = Error.prototype;
-  
   return result;
 })();


### PR DESCRIPTION
lib/Grammar.js is built by PEGJS, but it leaves lots of trailing whitespace on lines.

I thought it would be nice to clean that up.