### PR TITLE
Remove dangling callbacks after WebSocketInterface.disconnect().

### DIFF
--- a/lib/WebSocketInterface.js
+++ b/lib/WebSocketInterface.js
@@ -54,7 +54,7 @@ WebSocketInterface.prototype.connect = function () {
   }
 
   if (this.ws) {
-    this.ws.close();
+    this.disconnect();
   }
 
   debug('connecting to WebSocket ' + this.url);
@@ -77,7 +77,19 @@ WebSocketInterface.prototype.disconnect = function() {
   debug('disconnect()');
 
   if (this.ws) {
+    /* These callbacks may be delayed waiting for the actual close,
+     * which interferes with the smooth running of any replacement
+     * WS, so clear the callbacks and fake the close event instead.
+     */
+    var old_close_fn = this.ws.onclose;
+    this.ws.onopen    = null;
+    this.ws.onclose   = null;
+    this.ws.onmessage = null;
+    this.ws.onerror   = null;
     this.ws.close();
+    if ( old_close_fn ) {
+      old_close_fn({wasClean: true, code: 1000, reason: ''});
+    }
     this.ws = null;
   }
 };


### PR DESCRIPTION
- These callbacks may be delayed waiting for the actual close,
- which interferes with the smooth running of any replacement
- WS, so clear the callbacks and fake the close event instead.

The use-case which required this was to allow a controlled UA.stop() on loss of network and UA.start() when network returned. If this happend quickly, the callback events from the UA.stop() would cause the newly started instance to fail.
