### PR TITLE
Add before_reregister option.

### DIFF
--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -146,7 +146,14 @@ Registrator.prototype = {
           // For that, decrease the expires value. ie: 3 seconds
           this.registrationTimer = setTimeout(function() {
             self.registrationTimer = null;
-            self.register();
+
+            if (self.ua.configuration.before_reregister) {
+              self.ua.configuration.before_reregister.call(self.ua, function() {
+                self.register();
+              });
+            } else {
+              self.register();
+            }
           }, (expires * 1000) - 3000);
 
           //Save gruu values

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -698,6 +698,7 @@ UA.prototype.loadConfig = function(configuration) {
     register_expires: 600,
     register: true,
     registrar_server: null,
+    before_reregister: null,
 
     use_preloaded_route: false,
 
@@ -876,6 +877,9 @@ UA.prototype.loadConfig = function(configuration) {
       case 'ha1':
         debug('- ' + parameter + ': ' + 'NOT SHOWN');
         break;
+      case 'before_reregister':
+        debug('- ' + parameter + ': ' + typeof settings[parameter] === 'function' ? '<function>' : JSON.stringify(settings[parameter]));
+        break;
       default:
         debug('- ' + parameter + ': ' + JSON.stringify(settings[parameter]));
     }
@@ -913,6 +917,7 @@ UA.configuration_skeleton = (function() {
       'registrar_server',
       'sockets',
       'use_preloaded_route',
+      'before_reregister',
 
       // Post-configuration generated parameters
       'via_core_value',
@@ -1120,6 +1125,12 @@ UA.configuration_check = {
     use_preloaded_route: function(use_preloaded_route) {
       if (typeof use_preloaded_route === 'boolean') {
         return use_preloaded_route;
+      }
+    },
+
+    before_reregister: function(before_reregister) {
+      if (typeof before_reregister === 'function') {
+        return before_reregister;
       }
     }
   }


### PR DESCRIPTION
Set this to a function with a single callback argument.
Before JsSIP reregisters it will call the function.
The reregister will happen once you call the callback.
This gives you a chance to change some settings which
will affect the registration (e.g. generate a time-limited
token to register with).