### PR TITLE
Do not overwrite eventHandlers in sendDTMF function

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -919,7 +919,7 @@ RTCSession.prototype.sendDTMF = function(tones, options) {
       var dtmf = new RTCSession_DTMF(self);
       options.eventHandlers.failed = function() {
         self.tones = null;
-      }
+      };
       dtmf.send(tone, options);
       timeout = duration + interToneGap;
     }

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -917,9 +917,9 @@ RTCSession.prototype.sendDTMF = function(tones, options) {
       timeout = 2000;
     } else {
       var dtmf = new RTCSession_DTMF(self);
-      options.eventHandlers = {
-        failed: function() { self.tones = null; }
-      };
+      options.eventHandlers.failed = function() {
+        self.tones = null;
+      }
       dtmf.send(tone, options);
       timeout = duration + interToneGap;
     }


### PR DESCRIPTION
In the current implementation (2.0.x and up) all eventhandlers are overwritten in the sendDTMF function. 

In addition to this the eventhandlers 'succeeded' and 'failed' (like stated in the documentation) are never called because the actual implementation requires them to be called 'onSuccessResponse' and 'onErrorResponse'.

Regards,
Peter