### PR TITLE
Registration expiring event

### DIFF
--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -153,7 +153,7 @@ Registrator.prototype = {
             } else {
               self.ua.emit('registrationExpiring');
             }
-          }, (expires * 1000) - 3000);
+          }, (expires * 1000) - 5000);
 
           //Save gruu values
           if (contact.hasParam('temp-gruu')) {

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -142,11 +142,17 @@ Registrator.prototype = {
             expires = this.expires;
           }
 
-          // Re-Register before the expiration interval has elapsed.
+          // Re-Register or emit an event before the expiration interval has elapsed.
           // For that, decrease the expires value. ie: 3 seconds
           this.registrationTimer = setTimeout(function() {
             self.registrationTimer = null;
-            self.register();
+            // If there are no listeners for registrationExpiring, renew registration
+            // If there are listeners, let the function listening do the register call
+            if (self.ua.listeners('registrationExpiring').length === 0) {
+              self.register();
+            } else {
+              self.ua.emit('registrationEnding');
+            }
           }, (expires * 1000) - 3000);
 
           //Save gruu values

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -151,7 +151,7 @@ Registrator.prototype = {
             if (self.ua.listeners('registrationExpiring').length === 0) {
               self.register();
             } else {
-              self.ua.emit('registrationEnding');
+              self.ua.emit('registrationExpiring');
             }
           }, (expires * 1000) - 3000);
 


### PR DESCRIPTION
This allows people to listen for a registration expire event and then to manually call ua.register() themselves after doing some fancy logic 

This re-implements what the aim of #423 was attempting to fix.