### PR TITLE
Implements rtpTimeout and byeReceived RTCSession events

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1236,6 +1236,11 @@ RTCSession.prototype.receiveRequest = function(request) {
   var contentType,
       self = this;
 
+  function respondToBye(extraHeaders) {
+    request.reply(200, null, extraHeaders);
+    ended.call(self, 'remote', request, JsSIP_C.causes.BYE);
+  }
+
   if(request.method === JsSIP_C.CANCEL) {
     /* RFC3261 15 States that a UAS may have accepted an invitation while a CANCEL
     * was in progress and that the UAC MAY continue with the session established by
@@ -1305,8 +1310,14 @@ RTCSession.prototype.receiveRequest = function(request) {
         break;
       case JsSIP_C.BYE:
         if(this.status === C.STATUS_CONFIRMED) {
-          request.reply(200);
-          ended.call(this, 'remote', request, JsSIP_C.causes.BYE);
+          // if a byeReceived event handler is registered, postpone reply
+          if (this.listeners('byeReceived').length) {
+            this.emit('byeReceived', {
+              finishCallback : respondToBye
+            });
+          } else {
+            respondToBye();
+          }
         }
         else if (this.status === C.STATUS_INVITE_RECEIVED) {
           request.reply(200);
@@ -1509,13 +1520,30 @@ function createRTCConnection(pcConfig, rtcConstraints) {
   this.connection.addEventListener('iceconnectionstatechange', function() {
     var state = self.connection.iceConnectionState;
 
-    // TODO: Do more with different states.
-    if (state === 'failed') {
-      self.terminate({
+    function finishTerminate(extraHeaders) {
+      var terminateOptions = {
         cause: JsSIP_C.causes.RTP_TIMEOUT,
         status_code: 408,
         reason_phrase: JsSIP_C.causes.RTP_TIMEOUT
-      });
+      };
+
+      if (extraHeaders && extraHeaders.length) {
+        terminateOptions.extraHeaders = extraHeaders;
+      }
+
+      self.terminate(terminateOptions);
+    }
+
+    // TODO: Do more with different states.
+    if (state === 'failed') {
+      // if a rtpTimeout event handler is registered, postpone terminate
+      if (self.listeners('rtpTimeout').length) {
+        self.emit('rtpTimeout', {
+          finishCallback : finishTerminate
+        });
+      } else {
+        finishTerminate();
+      }
     }
   });
 }


### PR DESCRIPTION
If these events have handlers registered, call termination is
postponed. For both events, the event handler receives an event object
that has a 'finish' callback function. The callback function takes a
single argument 'extraHeaders'.

For the rtpTimeout event, the SIP 408 terminate message will be sent
with whatever extra headers are passed to the callback function.

For the byeReceived event, the SIP 200 response to the BYE message
will be sent with whatever extra headers are passed to the callback
function.

We are using these new callbacks so that we can send call
quality/statistics data via extra SIP headers.