### PR TITLE
Use promise chaining to prevent PeerConnection state race-conditions

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -65,6 +65,9 @@ module.exports = class RTCSession extends EventEmitter
     // The RTCPeerConnection instance (public attribute).
     this._connection = null;
 
+    // Prevent races on serial PeerConnction operations
+    this._connectionPromiseQueue = Promise.resolve();
+
     // Incoming/Outgoing request being currently processed.
     this._request = null;
 
@@ -667,7 +670,8 @@ module.exports = class RTCSession extends EventEmitter
 
         const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
 
-        this._connection.setRemoteDescription(offer)
+        this._connectionPromiseQueue = this._connectionPromiseQueue
+          .then(() => this._connection.setRemoteDescription(offer))
           .then(remoteDescriptionSucceededOrNotNeeded.bind(this))
           .catch((error) =>
           {
@@ -1391,7 +1395,8 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('sdp', e);
 
-            this._connection.setRemoteDescription(answer)
+            this._connectionPromiseQueue = this._connectionPromiseQueue
+              .then(() => this._connection.setRemoteDescription(answer))
               .then(() =>
               {
                 if (!this._is_confirmed)
@@ -1779,7 +1784,8 @@ module.exports = class RTCSession extends EventEmitter
 
     if (type === 'offer')
     {
-      connection.createOffer(constraints)
+      this._connectionPromiseQueue = this._connectionPromiseQueue
+        .then(() => connection.createOffer(constraints))
         .then(createSucceeded.bind(this))
         .catch((error) =>
         {
@@ -1793,7 +1799,8 @@ module.exports = class RTCSession extends EventEmitter
     }
     else if (type === 'answer')
     {
-      connection.createAnswer(constraints)
+      this._connectionPromiseQueue = this._connectionPromiseQueue
+        .then(() => connection.createAnswer(constraints))
         .then(createSucceeded.bind(this))
         .catch((error) =>
         {
@@ -2029,7 +2036,8 @@ module.exports = class RTCSession extends EventEmitter
 
       this.emit('sdp', e);
 
-      this._connection.setRemoteDescription(offer)
+      this._connectionPromiseQueue = this._connectionPromiseQueue
+        .then(() => this._connection.setRemoteDescription(offer))
         .then(doAnswer.bind(this))
         .catch((error) =>
         {
@@ -2202,7 +2210,8 @@ module.exports = class RTCSession extends EventEmitter
 
     const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
 
-    this._connection.setRemoteDescription(offer)
+    this._connectionPromiseQueue = this._connectionPromiseQueue
+      .then(() => this._connection.setRemoteDescription(offer))
       .then(() =>
       {
         if (this._remoteHold === true && hold === false)
@@ -2643,7 +2652,8 @@ module.exports = class RTCSession extends EventEmitter
 
         const answer = new RTCSessionDescription({ type: 'answer', sdp: e.sdp });
 
-        this._connection.setRemoteDescription(answer)
+        this._connectionPromiseQueue = this._connectionPromiseQueue
+          .then(() => this._connection.setRemoteDescription(answer))
           .catch((error) =>
           {
             debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
@@ -2677,7 +2687,7 @@ module.exports = class RTCSession extends EventEmitter
 
         const answer = new RTCSessionDescription({ type: 'answer', sdp: e.sdp });
 
-        Promise.resolve()
+        this._connectionPromiseQueue = this._connectionPromiseQueue
           .then(() =>
           {
             // Be ready for 200 with SDP after a 180/183 with SDP. We created a SDP 'answer'
@@ -2831,7 +2841,8 @@ module.exports = class RTCSession extends EventEmitter
 
       const answer = new RTCSessionDescription({ type: 'answer', sdp: e.sdp });
 
-      this._connection.setRemoteDescription(answer)
+      this._connectionPromiseQueue = this._connectionPromiseQueue
+        .then(() => this._connection.setRemoteDescription(answer))
         .then(() =>
         {
           if (eventHandlers.succeeded)
@@ -2993,7 +3004,8 @@ module.exports = class RTCSession extends EventEmitter
 
         const answer = new RTCSessionDescription({ type: 'answer', sdp: e.sdp });
 
-        this._connection.setRemoteDescription(answer)
+        this._connectionPromiseQueue = this._connectionPromiseQueue
+          .then(() => this._connection.setRemoteDescription(answer))
           .then(() =>
           {
             if (eventHandlers.succeeded)


### PR DESCRIPTION
The change which stopped using 'pranswer' introduced a race condition.

If a 183+SDP arrives, and the setRemoteDescription() is called, and then a 200+SDP arrives VERY quickly, and before the previous setRemoteDescription() has completed and resulted in a 'stable' state, then the attempt to apply the 2nd SDP causes a call drop due to invalid PC state.

I have tried to implement a general-purpose solution where all Promise capable PeerConnection calls are chained. It solves my issue.

PS. I am not keen on my 'connectionPromise' variable name - Feel free to find a better name!