### PR TITLE
Fix #457. referSubscriber was retrieving the key of the subscriber in…

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -2031,7 +2031,7 @@ function receiveNotify(request) {
         referSubscriber = this.referSubscribers[id];
       }
       else if (Object.keys(this.referSubscribers).length === 1) {
-        referSubscriber = Object.keys(this.referSubscribers)[0];
+        referSubscriber = this.referSubscribers[Object.keys(this.referSubscribers)[0]];
       }
       else {
         request.reply(400, 'Missing event id parameter');


### PR DESCRIPTION
A fix for the issue discussed in #457 
It seems referSubscriber was retrieving the key of the subscriber, instead of the actual value.