### PR TITLE
Fixed session.sendInfo()

### DIFF
--- a/lib/RTCSession/Info.js
+++ b/lib/RTCSession/Info.js
@@ -57,7 +57,7 @@ module.exports = class Info extends EventEmitter
       request    : this.request
     });
 
-    this._session.sendRequest(this, JsSIP_C.INFO, {
+    this._session.sendRequest(JsSIP_C.INFO, {
       extraHeaders,
       eventHandlers : {
         onSuccessResponse : (response) =>


### PR DESCRIPTION
Calling the session.sendRequest() with the correct parameters, so it can send the correct SIP INFO message.