### PR TITLE
UTF8 character can be coded on more than one Byte

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -337,7 +337,8 @@ module.exports = class Transport
     {
       try
       {
-        data = String.fromCharCode.apply(null, new Uint8Array(data));
+        //data = String.fromCharCode.apply(null, new Uint8Array(data));
+        data = Buffer.from(data).toString("utf8");
       }
       catch (evt)
       {


### PR DESCRIPTION
Hi guys,

It's probably just a forgetfullness but I point out the facts hat UTF8 character can be coded on 1,2,3 or 4 Byte thus parsing
binary data like so:
`data = String.fromCharCode.apply(null, new Uint8Array(data));`
will fail to restore special character like emoji 😔 .

This would be, I guess, the right way to do it (assuming the content is always text based ):
`data = Buffer.from(data).toString("utf8");`

Browserify automatically import [https://github.com/feross/buffer](url),
that implement the node.js Buffer API so it's okay to just call Buffer.from but it will increase the size of the lib so maybe you would prefer to implement it by hand...

Regards,

