### PR TITLE
Fix ordering of newRTCSession and peerconnection events

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -357,9 +357,6 @@ module.exports = class RTCSession extends EventEmitter
 
     this._id = this._request.call_id + this._from_tag;
 
-    // Create a new RTCPeerConnection instance.
-    this._createRTCConnection(pcConfig, rtcConstraints);
-
     // Set internal properties.
     this._direction = 'outgoing';
     this._local_identity = this._request.from;
@@ -372,6 +369,9 @@ module.exports = class RTCSession extends EventEmitter
     }
 
     this._newRTCSession('local', this._request);
+
+    // Create a new RTCPeerConnection instance.
+    this._createRTCConnection(pcConfig, rtcConstraints);
 
     this._sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream);
   }


### PR DESCRIPTION
The peer connection must be created after the newRTCSession method is called, otherwise the "peerconnection" event is fired before the "newRTCSession" event. This would be bad, because one typically attaches listeners for the "peerconnection" event in the "newRTCSession" callback!
