### PR TITLE
RTCSession: prefer promises over callbacks for readability

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -656,7 +656,7 @@ module.exports = class RTCSession extends EventEmitter
 
               this.emit('getusermediafailed', error);
 
-              return Promise.reject('getUserMedia');
+              throw new Error('getUserMedia');
             });
         }
       })
@@ -665,7 +665,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject(new Error('terminated'));
+          throw new Error('terminated');
         }
 
         this._localMediaStream = stream;
@@ -701,7 +701,7 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            return Promise.reject('setRemoteDescription');
+            throw new Error('setRemoteDescription');
           });
 
         return this._connectionPromiseQueue;
@@ -711,7 +711,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         // TODO: Is this event already useful?
@@ -724,7 +724,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               request.reply(500);
 
-              return Promise.reject('createLocalDescription');
+              throw new Error('createLocalDescription');
             });
         }
         else
@@ -734,7 +734,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               request.reply(500);
 
-              return Promise.reject('createLocalDescription');
+              throw new Error('createLocalDescription');
             });
         }
       })
@@ -743,7 +743,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         this._handleSessionTimersInIncomingRequest(request, extraHeaders);
@@ -2088,7 +2088,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         return this._connection.setRemoteDescription(offer)
@@ -2099,14 +2099,14 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            return Promise.reject('setRemoteDescription');
+            throw new Error('setRemoteDescription');
           });
       })
       .then(() =>
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         if (this._remoteHold === true && hold === false)
@@ -2125,7 +2125,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         return this._createLocalDescription('answer', this._rtcAnswerConstraints)
@@ -2133,7 +2133,7 @@ module.exports = class RTCSession extends EventEmitter
           {
             request.reply(500);
 
-            return Promise.reject('createLocalDescription');
+            throw new Error('createLocalDescription');
           });
       })
       // Send answer.
@@ -2141,7 +2141,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         sendAnswer(desc);
@@ -2291,7 +2291,7 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            return Promise.reject('setRemoteDescription');
+            throw new Error('setRemoteDescription');
           });
       })
       .then(() =>
@@ -2312,7 +2312,7 @@ module.exports = class RTCSession extends EventEmitter
           {
             request.reply(500);
 
-            return Promise.reject('createLocalDescription');
+            throw new Error('createLocalDescription');
           });
       })
       .then((desc) =>
@@ -2581,7 +2581,7 @@ module.exports = class RTCSession extends EventEmitter
 
               this.emit('getusermediafailed');
 
-              return Promise.reject('getUserMedia');
+              throw new Error('getUserMedia');
             });
         }
       })
@@ -2589,7 +2589,7 @@ module.exports = class RTCSession extends EventEmitter
       {
         if (this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         this._localMediaStream = stream;
@@ -2606,14 +2606,14 @@ module.exports = class RTCSession extends EventEmitter
           {
             this._failed('local', null, JsSIP_C.causes.WEBRTC_ERROR);
 
-            return Promise.reject('createLocalDescription');
+            throw new Error('createLocalDescription');
           });
       })
       .then((desc) =>
       {
         if (this._is_canceled || this._status === C.STATUS_TERMINATED)
         {
-          return Promise.reject('terminated');
+          throw new Error('terminated');
         }
 
         this._request.body = desc;

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -656,7 +656,7 @@ module.exports = class RTCSession extends EventEmitter
 
               this.emit('getusermediafailed', error);
 
-              throw new Error('getUserMedia');
+              throw new Error('getUserMedia() failed');
             });
         }
       })
@@ -701,7 +701,7 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            throw new Error('setRemoteDescription');
+            throw new Error('peerconnection.setRemoteDescription() failed');
           });
 
         return this._connectionPromiseQueue;
@@ -724,7 +724,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               request.reply(500);
 
-              throw new Error('createLocalDescription');
+              throw new Error('_createLocalDescription() failed');
             });
         }
         else
@@ -734,7 +734,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               request.reply(500);
 
-              throw new Error('createLocalDescription');
+              throw new Error('_createLocalDescription() failed');
             });
         }
       })
@@ -764,15 +764,14 @@ module.exports = class RTCSession extends EventEmitter
           }
         );
       })
-      .catch((step) =>
+      .catch((error) =>
       {
-        if (step !== 'getUserMedia' &&
-            step !== 'setRemoteDescription' &&
-            step !== 'createLocalDescription' &&
-            step !== 'terminated')
+        if (this._status === C.STATUS_TERMINATED)
         {
-          throw new Error(`Unhandled exception: ${step}`);
+          return;
         }
+
+        debugerror(error);
       });
   }
 
@@ -2099,7 +2098,7 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            throw new Error('setRemoteDescription');
+            throw new Error('peerconnection.setRemoteDescription() failed');
           });
       })
       .then(() =>
@@ -2133,7 +2132,7 @@ module.exports = class RTCSession extends EventEmitter
           {
             request.reply(500);
 
-            throw new Error('createLocalDescription');
+            throw new Error('_createLocalDescription() failed');
           });
       })
       // Send answer.
@@ -2146,14 +2145,14 @@ module.exports = class RTCSession extends EventEmitter
 
         sendAnswer(desc);
       })
-      .catch((step) =>
+      .catch((error) =>
       {
-        if (step !== 'setRemoteDescription' &&
-            step !== 'createLocalDescription' &&
-            step !== 'terminated')
+        if (this._status === C.STATUS_TERMINATED)
         {
-          throw new Error(`Unhandled exception: ${step}`);
+          return;
         }
+
+        debugerror(error);
       });
 
     function sendAnswer(desc)
@@ -2291,7 +2290,7 @@ module.exports = class RTCSession extends EventEmitter
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
 
-            throw new Error('setRemoteDescription');
+            throw new Error('peerconnection.setRemoteDescription() failed');
           });
       })
       .then(() =>
@@ -2312,7 +2311,7 @@ module.exports = class RTCSession extends EventEmitter
           {
             request.reply(500);
 
-            throw new Error('createLocalDescription');
+            throw new Error('_createLocalDescription() failed');
           });
       })
       .then((desc) =>
@@ -2328,13 +2327,14 @@ module.exports = class RTCSession extends EventEmitter
           data.callback();
         }
       })
-      .catch((step) =>
+      .catch((error) =>
       {
-        if (step !== 'setRemoteDescription' &&
-            step !== 'createLocalDescription')
+        if (this._status === C.STATUS_TERMINATED)
         {
-          throw new Error('Unknown failure step');
+          return;
         }
+
+        debugerror(error);
       });
   }
 
@@ -2581,7 +2581,7 @@ module.exports = class RTCSession extends EventEmitter
 
               this.emit('getusermediafailed');
 
-              throw new Error('getUserMedia');
+              throw new Error('getUserMedia() failed');
             });
         }
       })
@@ -2606,7 +2606,7 @@ module.exports = class RTCSession extends EventEmitter
           {
             this._failed('local', null, JsSIP_C.causes.WEBRTC_ERROR);
 
-            throw new Error('createLocalDescription');
+            throw new Error('_createLocalDescription() failed');
           });
       })
       .then((desc) =>
@@ -2628,14 +2628,14 @@ module.exports = class RTCSession extends EventEmitter
 
         request_sender.send();
       })
-      .catch((step) =>
+      .catch((error) =>
       {
-        if (step !== 'getUserMedia' &&
-            step !== 'createLocalDescription' &&
-            step !== 'terminated')
+        if (this._status === C.STATUS_TERMINATED)
         {
-          throw new Error(`Unhandled exception: ${step}`);
+          return;
         }
+
+        debugerror(error);
       });
   }
 

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -642,10 +642,19 @@ module.exports = class RTCSession extends EventEmitter
           this._localMediaStreamLocallyGenerated = true;
 
           return navigator.mediaDevices.getUserMedia(mediaConstraints)
-            .catch(() =>
+            .catch((error) =>
             {
+              if (this._status === C.STATUS_TERMINATED)
+              {
+                return;
+              }
+
               request.reply(480);
               this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
+
+              debugerror('emit "getusermediafailed" [error:%o]', error);
+
+              this.emit('getusermediafailed', error);
 
               return Promise.reject('getUserMedia');
             });
@@ -2561,6 +2570,11 @@ module.exports = class RTCSession extends EventEmitter
           return navigator.mediaDevices.getUserMedia(mediaConstraints)
             .catch((error) =>
             {
+              if (this._status === C.STATUS_TERMINATED)
+              {
+                return;
+              }
+
               this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
 
               debugerror('emit "getusermediafailed" [error:%o]', error);

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1990,7 +1990,6 @@ module.exports = class RTCSession extends EventEmitter
       reject   : reject.bind(this)
     };
 
-    let hold = false;
     let rejected = false;
 
     function reject(options = {})
@@ -2032,7 +2031,7 @@ module.exports = class RTCSession extends EventEmitter
       this._createLocalDescription('offer', this._rtcOfferConstraints)
         .then((sdp) =>
         {
-          sendAnswer(sdp);
+          sendAnswer.call(this, sdp);
         })
         .catch(() =>
         {
@@ -2051,7 +2050,150 @@ module.exports = class RTCSession extends EventEmitter
       return;
     }
 
+    this._processInDialogSdpOffer(request)
+      // Send answer.
+      .then((desc) =>
+      {
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return;
+        }
+
+        sendAnswer.call(this, desc);
+      })
+      .catch((error) =>
+      {
+        debugerror(error);
+      });
+
+    function sendAnswer(desc)
+    {
+      const extraHeaders = [ `Contact: ${this._contact}` ];
+
+      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
+
+      if (this._late_sdp)
+      {
+        desc = this._mangleOffer(desc);
+      }
+
+      request.reply(200, null, extraHeaders, desc,
+        () =>
+        {
+          this._status = C.STATUS_WAITING_FOR_ACK;
+          this._setInvite2xxTimer(request, desc);
+          this._setACKTimer();
+        }
+      );
+
+      // If callback is given execute it.
+      if (typeof data.callback === 'function')
+      {
+        data.callback();
+      }
+    }
+  }
+
+  /**
+   * In dialog UPDATE Reception
+   */
+  _receiveUpdate(request)
+  {
+    debug('receiveUpdate()');
+
+    const contentType = request.getHeader('Content-Type');
+    const data = {
+      request,
+      callback : undefined,
+      reject   : reject.bind(this)
+    };
+
+    let rejected = false;
+
+    function reject(options = {})
+    {
+      rejected = true;
+
+      const status_code = options.status_code || 403;
+      const reason_phrase = options.reason_phrase || '';
+      const extraHeaders = Utils.cloneArray(options.extraHeaders);
+
+      if (this._status !== C.STATUS_CONFIRMED)
+      {
+        return false;
+      }
+
+      if (status_code < 300 || status_code >= 700)
+      {
+        throw new TypeError(`Invalid status_code: ${status_code}`);
+      }
+
+      request.reply(status_code, reason_phrase, extraHeaders);
+    }
+
+    // Emit 'update'.
+    this.emit('update', data);
+
+    if (rejected)
+    {
+      return;
+    }
+
+    if (! request.body)
+    {
+      sendAnswer.call(this, null);
+
+      return;
+    }
+
+    if (contentType !== 'application/sdp')
+    {
+      debug('invalid Content-Type');
+
+      request.reply(415);
+
+      return;
+    }
+
+    this._processInDialogSdpOffer(request)
+      // Send answer.
+      .then((desc) =>
+      {
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return;
+        }
+
+        sendAnswer.call(this, desc);
+      })
+      .catch((error) =>
+      {
+        debugerror(error);
+      });
+
+    function sendAnswer(desc)
+    {
+      const extraHeaders = [ `Contact: ${this._contact}` ];
+
+      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
+
+      request.reply(200, null, extraHeaders, desc);
+
+      // If callback is given execute it.
+      if (typeof data.callback === 'function')
+      {
+        data.callback();
+      }
+    }
+  }
+
+  _processInDialogSdpOffer(request)
+  {
+    debug('_processInDialogSdpOffer()');
+
     const sdp = request.parseSDP();
+
+    let hold = false;
 
     for (const m of sdp.media)
     {
@@ -2134,208 +2276,9 @@ module.exports = class RTCSession extends EventEmitter
 
             throw new Error('_createLocalDescription() failed');
           });
-      })
-      // Send answer.
-      .then((desc) =>
-      {
-        if (this._status === C.STATUS_TERMINATED)
-        {
-          throw new Error('terminated');
-        }
-
-        sendAnswer(desc);
-      })
-      .catch((error) =>
-      {
-        if (this._status === C.STATUS_TERMINATED)
-        {
-          return;
-        }
-
-        debugerror(error);
       });
 
-    function sendAnswer(desc)
-    {
-      const extraHeaders = [ `Contact: ${this._contact}` ];
-
-      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-
-      if (this._late_sdp)
-      {
-        desc = this._mangleOffer(desc);
-      }
-
-      request.reply(200, null, extraHeaders, desc,
-        () =>
-        {
-          this._status = C.STATUS_WAITING_FOR_ACK;
-          this._setInvite2xxTimer(request, desc);
-          this._setACKTimer();
-        }
-      );
-
-      // If callback is given execute it.
-      if (typeof data.callback === 'function')
-      {
-        data.callback();
-      }
-    }
-  }
-
-  /**
-   * In dialog UPDATE Reception
-   */
-  _receiveUpdate(request)
-  {
-    debug('receiveUpdate()');
-
-    const contentType = request.getHeader('Content-Type');
-    const data = {
-      request,
-      callback : undefined,
-      reject   : reject.bind(this)
-    };
-
-    let rejected = false;
-    let hold = false;
-
-    function reject(options = {})
-    {
-      rejected = true;
-
-      const status_code = options.status_code || 403;
-      const reason_phrase = options.reason_phrase || '';
-      const extraHeaders = Utils.cloneArray(options.extraHeaders);
-
-      if (this._status !== C.STATUS_CONFIRMED)
-      {
-        return false;
-      }
-
-      if (status_code < 300 || status_code >= 700)
-      {
-        throw new TypeError(`Invalid status_code: ${status_code}`);
-      }
-
-      request.reply(status_code, reason_phrase, extraHeaders);
-    }
-
-    // Emit 'update'.
-    this.emit('update', data);
-
-    if (rejected)
-    {
-      return;
-    }
-
-    if (! request.body)
-    {
-      const extraHeaders = [];
-
-      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-      request.reply(200, null, extraHeaders);
-
-      return;
-    }
-
-    if (contentType !== 'application/sdp')
-    {
-      debug('invalid Content-Type');
-
-      request.reply(415);
-
-      return;
-    }
-
-    const sdp = request.parseSDP();
-
-    for (const m of sdp.media)
-    {
-
-      if (holdMediaTypes.indexOf(m.type) === -1)
-      {
-        continue;
-      }
-
-      const direction = m.direction || sdp.direction || 'sendrecv';
-
-      if (direction === 'sendonly' || direction === 'inactive')
-      {
-        hold = true;
-      }
-      // If at least one of the streams is active don't emit 'hold'.
-      else
-      {
-        hold = false;
-        break;
-      }
-    }
-
-    const e = { originator: 'remote', type: 'offer', sdp: request.body };
-
-    debug('emit "sdp"');
-    this.emit('sdp', e);
-
-    const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
-
-    this._connectionPromiseQueue = this._connectionPromiseQueue
-      .then(() =>
-      {
-        return this._connection.setRemoteDescription(offer)
-          .catch((error) =>
-          {
-            request.reply(488);
-            debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
-
-            this.emit('peerconnection:setremotedescriptionfailed', error);
-
-            throw new Error('peerconnection.setRemoteDescription() failed');
-          });
-      })
-      .then(() =>
-      {
-        if (this._remoteHold === true && hold === false)
-        {
-          this._remoteHold = false;
-          this._onunhold('remote');
-        }
-        else if (this._remoteHold === false && hold === true)
-        {
-          this._remoteHold = true;
-          this._onhold('remote');
-        }
-
-        return this._createLocalDescription('answer')
-          .catch(() =>
-          {
-            request.reply(500);
-
-            throw new Error('_createLocalDescription() failed');
-          });
-      })
-      .then((desc) =>
-      {
-        const extraHeaders = [ `Contact: ${this._contact}` ];
-
-        this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-        request.reply(200, null, extraHeaders, desc);
-
-        // If callback is given execute it.
-        if (typeof data.callback === 'function')
-        {
-          data.callback();
-        }
-      })
-      .catch((error) =>
-      {
-        if (this._status === C.STATUS_TERMINATED)
-        {
-          return;
-        }
-
-        debugerror(error);
-      });
+    return this._connectionPromiseQueue;
   }
 
   /**

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -626,45 +626,53 @@ module.exports = class RTCSession extends EventEmitter
     // TODO: This may throw an error, should react.
     this._createRTCConnection(pcConfig, rtcConstraints);
 
-    // If a local MediaStream is given use it.
-    if (mediaStream)
-    {
-      userMediaSucceeded.call(this, mediaStream);
-    }
-    // If at least audio or video is requested prompt getUserMedia.
-    else if (mediaConstraints.audio || mediaConstraints.video)
-    {
-      this._localMediaStreamLocallyGenerated = true;
-      navigator.mediaDevices.getUserMedia(mediaConstraints)
-        .then(userMediaSucceeded.bind(this))
-        .catch((error) =>
+    Promise.resolve()
+      // Handle local MediaStream.
+      .then(() =>
+      {
+        // A local MediaStream is given, use it.
+        if (mediaStream)
         {
-          userMediaFailed.call(this, error);
+          return mediaStream;
+        }
 
-          debugerror('emit "getusermediafailed" [error:%o]', error);
+        // Audio and/or video requested, prompt getUserMedia.
+        else if (mediaConstraints.audio || mediaConstraints.video)
+        {
+          this._localMediaStreamLocallyGenerated = true;
 
-          this.emit('getusermediafailed', error);
-        });
-    // Otherwise don't prompt getUserMedia.
-    }
-    else
-    {
-      userMediaSucceeded.call(this, null);
-    }
+          return navigator.mediaDevices.getUserMedia(mediaConstraints)
+            .catch(() =>
+            {
+              request.reply(480);
+              this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
 
-    // User media succeeded.
-    function userMediaSucceeded(stream)
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
-
-      this._localMediaStream = stream;
-      if (stream)
+              return Promise.reject('getUserMedia');
+            });
+        }
+      })
+      // Attach MediaStream to RTCPeerconnection.
+      .then((stream) =>
       {
-        this._connection.addStream(stream);
-      }
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject(new Error('terminated'));
+        }
 
-      if (! this._late_sdp)
+        this._localMediaStream = stream;
+        if (stream)
+        {
+          this._connection.addStream(stream);
+        }
+      })
+      // Set remote description.
+      .then(() =>
       {
+        if (this._late_sdp)
+        {
+          return;
+        }
+
         const e = { originator: 'remote', type: 'offer', sdp: request.body };
 
         debug('emit "sdp"');
@@ -674,81 +682,89 @@ module.exports = class RTCSession extends EventEmitter
 
         this._connectionPromiseQueue = this._connectionPromiseQueue
           .then(() => this._connection.setRemoteDescription(offer))
-          .then(remoteDescriptionSucceededOrNotNeeded.bind(this))
           .catch((error) =>
           {
             request.reply(488);
+
             this._failed('system', null, JsSIP_C.causes.WEBRTC_ERROR);
 
             debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
 
             this.emit('peerconnection:setremotedescriptionfailed', error);
+
+            return Promise.reject('setRemoteDescription');
           });
-      }
-      else
+
+        return this._connectionPromiseQueue;
+      })
+      // Create local description.
+      .then(() =>
       {
-        remoteDescriptionSucceededOrNotNeeded.call(this);
-      }
-    }
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
 
-    // User media failed.
-    function userMediaFailed()
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
+        // TODO: Is this event already useful?
+        this._connecting(request);
 
-      request.reply(480);
-      this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
-    }
+        if (! this._late_sdp)
+        {
+          return this._createLocalDescription('answer', rtcAnswerConstraints)
+            .catch(() =>
+            {
+              request.reply(500);
 
-    function remoteDescriptionSucceededOrNotNeeded()
-    {
-      this._connecting(request);
-      if (! this._late_sdp)
+              return Promise.reject('createLocalDescription');
+            });
+        }
+        else
+        {
+          return this._createLocalDescription('offer', this._rtcOfferConstraints)
+            .catch(() =>
+            {
+              request.reply(500);
+
+              return Promise.reject('createLocalDescription');
+            });
+        }
+      })
+      // Send reply.
+      .then((desc) =>
       {
-        this._createLocalDescription('answer', rtcSucceeded.bind(this), rtcFailed.bind(this), rtcAnswerConstraints);
-      }
-      else
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
+
+        this._handleSessionTimersInIncomingRequest(request, extraHeaders);
+
+        request.reply(200, null, extraHeaders,
+          desc,
+          () =>
+          {
+            this._status = C.STATUS_WAITING_FOR_ACK;
+
+            this._setInvite2xxTimer(request, desc);
+            this._setACKTimer();
+            this._accepted('local');
+          },
+          () =>
+          {
+            this._failed('system', null, JsSIP_C.causes.CONNECTION_ERROR);
+          }
+        );
+      })
+      .catch((step) =>
       {
-        this._createLocalDescription('offer', rtcSucceeded.bind(this), rtcFailed.bind(this), this._rtcOfferConstraints);
-      }
-    }
-
-    function rtcSucceeded(desc)
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
-
-      // Run for reply success callback.
-      function replySucceeded()
-      {
-        this._status = C.STATUS_WAITING_FOR_ACK;
-
-        this._setInvite2xxTimer(request, desc);
-        this._setACKTimer();
-        this._accepted('local');
-      }
-
-      // Run for reply failure callback.
-      function replyFailed()
-      {
-        this._failed('system', null, JsSIP_C.causes.CONNECTION_ERROR);
-      }
-
-      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-
-      request.reply(200, null, extraHeaders,
-        desc,
-        replySucceeded.bind(this),
-        replyFailed.bind(this)
-      );
-    }
-
-    function rtcFailed()
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
-
-      request.reply(500);
-      this._failed('system', null, JsSIP_C.causes.WEBRTC_ERROR);
-    }
+        if (step !== 'getUserMedia' &&
+            step !== 'setRemoteDescription' &&
+            step !== 'createLocalDescription' &&
+            step !== 'terminated')
+        {
+          throw new Error(`Unhandled exception: ${step}`);
+        }
+      });
   }
 
   /**
@@ -1779,107 +1795,103 @@ module.exports = class RTCSession extends EventEmitter
     });
   }
 
-  _createLocalDescription(type, onSuccess, onFailure, constraints)
+  _createLocalDescription(type, constraints)
   {
     debug('createLocalDescription()');
+
+    if (type !== 'offer' && type !== 'answer')
+      throw new Error(`createLocalDescription() | invalid type "${type}"`);
 
     const connection = this._connection;
 
     this._rtcReady = false;
 
-    if (type === 'offer')
-    {
-      this._connectionPromiseQueue = this._connectionPromiseQueue
-        .then(() => connection.createOffer(constraints))
-        .then(createSucceeded.bind(this))
-        .catch((error) =>
-        {
-          this._rtcReady = true;
-          if (onFailure) { onFailure(error); }
-
-          debugerror('emit "peerconnection:createofferfailed" [error:%o]', error);
-
-          this.emit('peerconnection:createofferfailed', error);
-        });
-    }
-    else if (type === 'answer')
-    {
-      this._connectionPromiseQueue = this._connectionPromiseQueue
-        .then(() => connection.createAnswer(constraints))
-        .then(createSucceeded.bind(this))
-        .catch((error) =>
-        {
-          this._rtcReady = true;
-          if (onFailure) { onFailure(error); }
-
-          debugerror('emit "peerconnection:createanswerfailed" [error:%o]', error);
-
-          this.emit('peerconnection:createanswerfailed', error);
-        });
-    }
-    else
-    {
-      throw new Error(`createLocalDescription() | type must be "offer" or "answer", but "${type}" was given`);
-    }
-
-    // CreateAnswer or createOffer succeeded.
-    function createSucceeded(desc)
-    {
-      let listener;
-
-      connection.addEventListener('icecandidate', listener = (event) =>
+    return Promise.resolve()
+      // Create Offer or Answer.
+      .then(() =>
       {
-        const candidate = event.candidate;
-
-        if (! candidate)
+        if (type === 'offer')
         {
-          connection.removeEventListener('icecandidate', listener);
-          this._rtcReady = true;
+          return connection.createOffer(constraints)
+            .catch((error) =>
+            {
+              debugerror('emit "peerconnection:createofferfailed" [error:%o]', error);
 
-          if (onSuccess)
-          {
-            const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
+              this.emit('peerconnection:createofferfailed', error);
 
-            debug('emit "sdp"');
-
-            this.emit('sdp', e);
-            onSuccess(e.sdp);
-          }
-          onSuccess = null;
+              return Promise.reject(error);
+            });
         }
-      });
-
-      connection.setLocalDescription(desc)
-        .then(() =>
+        else
         {
-          if (connection.iceGatheringState === 'complete')
+          return connection.createAnswer(constraints)
+            .catch((error) =>
+            {
+              debugerror('emit "peerconnection:createanswerfailed" [error:%o]', error);
+
+              this.emit('peerconnection:createanswerfailed', error);
+
+              return Promise.reject(error);
+            });
+        }
+      })
+      // Set local description.
+      .then((desc) =>
+      {
+        return connection.setLocalDescription(desc)
+          .catch((error) =>
           {
             this._rtcReady = true;
 
-            if (onSuccess)
+            debugerror('emit "peerconnection:setlocaldescriptionfailed" [error:%o]', error);
+
+            this.emit('peerconnection:setlocaldescriptionfailed', error);
+
+            return Promise.reject(error);
+          });
+      })
+      .then(() =>
+      {
+        // Resolve right away if 'pc.iceGatheringState' is 'complete'.
+        if (connection.iceGatheringState === 'complete')
+        {
+          this._rtcReady = true;
+
+          const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
+
+          debug('emit "sdp"');
+
+          this.emit('sdp', e);
+
+          return Promise.resolve(e.sdp);
+        }
+
+        // Add 'pc.onicencandidate' event handler to resolve on last candidate.
+        return new Promise((resolve) =>
+        {
+          let listener;
+
+          connection.addEventListener('icecandidate', listener = (event) =>
+          {
+            const candidate = event.candidate;
+
+            if (! candidate)
             {
+              connection.removeEventListener('icecandidate', listener);
+              this._rtcReady = true;
+
               const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
 
               debug('emit "sdp"');
 
               this.emit('sdp', e);
-              onSuccess(e.sdp);
-              onSuccess = null;
+
+              resolve(e.sdp);
             }
-          }
-        })
-        .catch((error) =>
-        {
-          this._rtcReady = true;
-          if (onFailure) { onFailure(error); }
-
-          debugerror('emit "peerconnection:setlocaldescriptionfailed" [error:%o]', error);
-
-          this.emit('peerconnection:setlocaldescriptionfailed', error);
+          });
         });
-    }
+      });
   }
-
 
   /**
    * Dialog Management
@@ -2002,105 +2014,92 @@ module.exports = class RTCSession extends EventEmitter
       return;
     }
 
-    if (request.body)
-    {
-      this._late_sdp = false;
-      if (contentType !== 'application/sdp')
-      {
-        debug('invalid Content-Type');
-        request.reply(415);
+    this._late_sdp = false;
 
-        return;
-      }
-
-      const sdp = request.parseSDP();
-
-      for (const m of sdp.media)
-      {
-        if (holdMediaTypes.indexOf(m.type) === -1)
-        {
-          continue;
-        }
-
-        const direction = m.direction || sdp.direction || 'sendrecv';
-
-        if (direction === 'sendonly' || direction === 'inactive')
-        {
-          hold = true;
-        }
-        // If at least one of the streams is active don't emit 'hold'.
-        else
-        {
-          hold = false;
-          break;
-        }
-      }
-
-      const e = { originator: 'remote', type: 'offer', sdp: request.body };
-
-      debug('emit "sdp"');
-      this.emit('sdp', e);
-
-      const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
-
-      this._connectionPromiseQueue = this._connectionPromiseQueue
-        .then(() => this._connection.setRemoteDescription(offer))
-        .then(doAnswer.bind(this))
-        .catch((error) =>
-        {
-          request.reply(488);
-
-          debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
-
-          this.emit('peerconnection:setremotedescriptionfailed', error);
-        });
-    }
-    else
+    // Request without SDP.
+    if (!request.body)
     {
       this._late_sdp = true;
-      doAnswer.call(this);
-    }
 
-    function doAnswer()
-    {
-      createSdp.call(this,
-        (sdp) =>
+      this._createLocalDescription('offer', this._rtcOfferConstraints)
+        .then((sdp) =>
         {
-          const extraHeaders = [ `Contact: ${this._contact}` ];
-
-          this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-
-          if (this._late_sdp)
-          {
-            sdp = this._mangleOffer(sdp);
-          }
-
-          request.reply(200, null, extraHeaders, sdp,
-            () =>
-            {
-              this._status = C.STATUS_WAITING_FOR_ACK;
-              this._setInvite2xxTimer(request, sdp);
-              this._setACKTimer();
-            }
-          );
-
-          // If callback is given execute it.
-          if (typeof data.callback === 'function')
-          {
-            data.callback();
-          }
-        },
-        () =>
+          sendAnswer(sdp);
+        })
+        .catch(() =>
         {
           request.reply(500);
-        }
-      );
+        });
+
+      return;
     }
 
-    function createSdp(onSuccess, onFailure)
+    // Request with SDP.
+    if (contentType !== 'application/sdp')
     {
-      if (! this._late_sdp)
+      debug('invalid Content-Type');
+      request.reply(415);
+
+      return;
+    }
+
+    const sdp = request.parseSDP();
+
+    for (const m of sdp.media)
+    {
+      if (holdMediaTypes.indexOf(m.type) === -1)
       {
+        continue;
+      }
+
+      const direction = m.direction || sdp.direction || 'sendrecv';
+
+      if (direction === 'sendonly' || direction === 'inactive')
+      {
+        hold = true;
+      }
+      // If at least one of the streams is active don't emit 'hold'.
+      else
+      {
+        hold = false;
+        break;
+      }
+    }
+
+    const e = { originator: 'remote', type: 'offer', sdp: request.body };
+
+    debug('emit "sdp"');
+    this.emit('sdp', e);
+
+    const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
+
+    this._connectionPromiseQueue = this._connectionPromiseQueue
+      // Set remote description.
+      .then(() =>
+      {
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
+
+        return this._connection.setRemoteDescription(offer)
+          .catch((error) =>
+          {
+            request.reply(488);
+            debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
+
+            this.emit('peerconnection:setremotedescriptionfailed', error);
+
+            return Promise.reject('setRemoteDescription');
+          });
+      })
+      .then(() =>
+      {
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
+
         if (this._remoteHold === true && hold === false)
         {
           this._remoteHold = false;
@@ -2111,12 +2110,67 @@ module.exports = class RTCSession extends EventEmitter
           this._remoteHold = true;
           this._onhold('remote');
         }
-
-        this._createLocalDescription('answer', onSuccess, onFailure, this._rtcAnswerConstraints);
-      }
-      else
+      })
+      // Create local description.
+      .then(() =>
       {
-        this._createLocalDescription('offer', onSuccess, onFailure, this._rtcOfferConstraints);
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
+
+        return this._createLocalDescription('answer', this._rtcAnswerConstraints)
+          .catch(() =>
+          {
+            request.reply(500);
+
+            return Promise.reject('createLocalDescription');
+          });
+      })
+      // Send answer.
+      .then((desc) =>
+      {
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
+
+        sendAnswer(desc);
+      })
+      .catch((step) =>
+      {
+        if (step !== 'setRemoteDescription' &&
+            step !== 'createLocalDescription' &&
+            step !== 'terminated')
+        {
+          throw new Error(`Unhandled exception: ${step}`);
+        }
+      });
+
+    function sendAnswer(desc)
+    {
+      const extraHeaders = [ `Contact: ${this._contact}` ];
+
+      this._handleSessionTimersInIncomingRequest(request, extraHeaders);
+
+      if (this._late_sdp)
+      {
+        desc = this._mangleOffer(desc);
+      }
+
+      request.reply(200, null, extraHeaders, desc,
+        () =>
+        {
+          this._status = C.STATUS_WAITING_FOR_ACK;
+          this._setInvite2xxTimer(request, desc);
+          this._setACKTimer();
+        }
+      );
+
+      // If callback is given execute it.
+      if (typeof data.callback === 'function')
+      {
+        data.callback();
       }
     }
   }
@@ -2218,7 +2272,19 @@ module.exports = class RTCSession extends EventEmitter
     const offer = new RTCSessionDescription({ type: 'offer', sdp: e.sdp });
 
     this._connectionPromiseQueue = this._connectionPromiseQueue
-      .then(() => this._connection.setRemoteDescription(offer))
+      .then(() =>
+      {
+        return this._connection.setRemoteDescription(offer)
+          .catch((error) =>
+          {
+            request.reply(488);
+            debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
+
+            this.emit('peerconnection:setremotedescriptionfailed', error);
+
+            return Promise.reject('setRemoteDescription');
+          });
+      })
       .then(() =>
       {
         if (this._remoteHold === true && hold === false)
@@ -2232,33 +2298,34 @@ module.exports = class RTCSession extends EventEmitter
           this._onhold('remote');
         }
 
-        this._createLocalDescription('answer',
-          (answerSdp) =>
-          {
-            const extraHeaders = [ `Contact: ${this._contact}` ];
-
-            this._handleSessionTimersInIncomingRequest(request, extraHeaders);
-            request.reply(200, null, extraHeaders, answerSdp);
-
-            // If callback is given execute it.
-            if (typeof data.callback === 'function')
-            {
-              data.callback();
-            }
-          },
-          () =>
+        return this._createLocalDescription('answer')
+          .catch(() =>
           {
             request.reply(500);
-          }
-        );
+
+            return Promise.reject('createLocalDescription');
+          });
       })
-      .catch((error) =>
+      .then((desc) =>
       {
-        request.reply(488);
+        const extraHeaders = [ `Contact: ${this._contact}` ];
 
-        debugerror('emit "peerconnection:setremotedescriptionfailed" [error:%o]', error);
+        this._handleSessionTimersInIncomingRequest(request, extraHeaders);
+        request.reply(200, null, extraHeaders, desc);
 
-        this.emit('peerconnection:setremotedescriptionfailed', error);
+        // If callback is given execute it.
+        if (typeof data.callback === 'function')
+        {
+          data.callback();
+        }
+      })
+      .catch((step) =>
+      {
+        if (step !== 'setRemoteDescription' &&
+            step !== 'createLocalDescription')
+        {
+          throw new Error('Unknown failure step');
+        }
       });
   }
 
@@ -2476,82 +2543,86 @@ module.exports = class RTCSession extends EventEmitter
       }
     });
 
-    // If a local MediaStream is given use it.
-    if (mediaStream)
-    {
-      // Wait a bit so the app can set events such as 'peerconnection' and 'connecting'.
-      setTimeout(() =>
+    Promise.resolve()
+      // Get a stream if required.
+      .then(() =>
       {
-        userMediaSucceeded.call(this, mediaStream);
-      });
-    // If at least audio or video is requested prompt getUserMedia.
-    }
-    else if (mediaConstraints.audio || mediaConstraints.video)
-    {
-      this._localMediaStreamLocallyGenerated = true;
-      navigator.mediaDevices.getUserMedia(mediaConstraints)
-        .then(userMediaSucceeded.bind(this))
-        .catch((error) =>
+        // A stream is given, let the app set events such as 'peerconnection' and 'connecting'.
+        if (mediaStream)
         {
-          userMediaFailed.call(this, error);
+          setTimeout(() => Promise.resolve);
+        }
 
-          debugerror('emit "getusermediafailed" [error:%o]', error);
+        // Request for user media access.
+        else if (mediaConstraints.audio || mediaConstraints.video)
+        {
+          this._localMediaStreamLocallyGenerated = true;
 
-          this.emit('getusermediafailed', error);
-        });
-    // Otherwise don't prompt getUserMedia.
-    }
-    else
-    {
-      userMediaSucceeded.call(this, null);
-    }
+          return navigator.mediaDevices.getUserMedia(mediaConstraints)
+            .catch((error) =>
+            {
+              this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
 
-    // User media succeeded.
-    function userMediaSucceeded(stream)
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
+              debugerror('emit "getusermediafailed" [error:%o]', error);
 
-      this._localMediaStream = stream;
-      if (stream)
+              this.emit('getusermediafailed');
+
+              return Promise.reject('getUserMedia');
+            });
+        }
+      })
+      .then((stream) =>
       {
-        this._connection.addStream(stream);
-      }
+        if (this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
 
-      this._connecting(this._request);
-      this._createLocalDescription('offer', rtcSucceeded.bind(this), rtcFailed.bind(this), rtcOfferConstraints);
-    }
+        this._localMediaStream = stream;
+        if (stream)
+        {
+          this._connection.addStream(stream);
+        }
 
-    // User media failed.
-    function userMediaFailed()
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
+        // TODO: should this be triggered here?
+        this._connecting(this._request);
 
-      this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);
-    }
+        return this._createLocalDescription('offer', rtcOfferConstraints)
+          .catch(() =>
+          {
+            this._failed('local', null, JsSIP_C.causes.WEBRTC_ERROR);
 
-    function rtcSucceeded(desc)
-    {
-      if (this._is_canceled || this._status === C.STATUS_TERMINATED) { return; }
+            return Promise.reject('createLocalDescription');
+          });
+      })
+      .then((desc) =>
+      {
+        if (this._is_canceled || this._status === C.STATUS_TERMINATED)
+        {
+          return Promise.reject('terminated');
+        }
 
-      this._request.body = desc;
-      this._status = C.STATUS_INVITE_SENT;
+        this._request.body = desc;
+        this._status = C.STATUS_INVITE_SENT;
 
-      debug('emit "sending" [request:%o]', this._request);
+        debug('emit "sending" [request:%o]', this._request);
 
-      // Emit 'sending' so the app can mangle the body before the request is sent.
-      this.emit('sending', {
-        request : this._request
+        // Emit 'sending' so the app can mangle the body before the request is sent.
+        this.emit('sending', {
+          request : this._request
+        });
+
+        request_sender.send();
+      })
+      .catch((step) =>
+      {
+        if (step !== 'getUserMedia' &&
+            step !== 'createLocalDescription' &&
+            step !== 'terminated')
+        {
+          throw new Error(`Unhandled exception: ${step}`);
+        }
       });
-
-      request_sender.send();
-    }
-
-    function rtcFailed()
-    {
-      if (this._status === C.STATUS_TERMINATED) { return; }
-
-      this._failed('system', null, JsSIP_C.causes.WEBRTC_ERROR);
-    }
   }
 
   /**
@@ -2706,10 +2777,6 @@ module.exports = class RTCSession extends EventEmitter
                 {
                   this._acceptAndTerminate(response, 500, error.toString());
                   this._failed('local', response, JsSIP_C.causes.WEBRTC_ERROR);
-
-                  debugerror('emit "peerconnection:setlocaldescriptionfailed" [error:%o]', error);
-
-                  this.emit('peerconnection:setlocaldescriptionfailed', error);
                 });
             }
           })
@@ -2770,8 +2837,8 @@ module.exports = class RTCSession extends EventEmitter
       extraHeaders.push(`Session-Expires: ${this._sessionTimers.currentExpires};refresher=${this._sessionTimers.refresher ? 'uac' : 'uas'}`);
     }
 
-    this._createLocalDescription('offer',
-      (sdp) =>
+    this._createLocalDescription('offer', rtcOfferConstraints)
+      .then((sdp) =>
       {
         sdp = this._mangleOffer(sdp);
 
@@ -2802,14 +2869,11 @@ module.exports = class RTCSession extends EventEmitter
             }
           }
         });
-      },
-      () =>
+      })
+      .catch(() =>
       {
         onFailed();
-      },
-      // RTC constraints.
-      rtcOfferConstraints
-    );
+      });
 
     function onSucceeded(response)
     {
@@ -2902,8 +2966,8 @@ module.exports = class RTCSession extends EventEmitter
     {
       extraHeaders.push('Content-Type: application/sdp');
 
-      this._createLocalDescription('offer',
-        (sdp) =>
+      this._createLocalDescription('offer', rtcOfferConstraints)
+        .then((sdp) =>
         {
           sdp = this._mangleOffer(sdp);
 
@@ -2934,14 +2998,11 @@ module.exports = class RTCSession extends EventEmitter
               }
             }
           });
-        },
-        () =>
+        })
+        .catch(() =>
         {
           onFailed.call(this);
-        },
-        // RTC constraints.
-        rtcOfferConstraints
-      );
+        });
     }
 
     // No SDP.

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -646,7 +646,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               if (this._status === C.STATUS_TERMINATED)
               {
-                return;
+                throw new Error('terminated');
               }
 
               request.reply(480);
@@ -2572,7 +2572,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               if (this._status === C.STATUS_TERMINATED)
               {
-                return;
+                throw new Error('terminated');
               }
 
               this._failed('local', null, JsSIP_C.causes.USER_DENIED_MEDIA_ACCESS);


### PR DESCRIPTION
This is a refactor exercise on replacing callbacks with promises.

It provides readability and makes it easier to follow the flow.

The approach has been dealing with each scope in its own block. Ie:

```js
return Promise.resolve()
  // Block A
  then(() =>
  {
     return MethodReturningPromise
       .catch(() =>
       {
          // Block A error handling here.
          return Promise.reject('Block A');
       });
  })
  // Block B
  then(() =>
  {
     return MethodReturningPromise
       .catch(() =>
       {
          // Block B error handling here.
          return Promise.reject('Block B');
       });
  })
  catch((step) =>
  {
     if (step !== 'Block A' && step !== 'Block B')
       throw new Error(Unhandled exeption);
  }
```

As said, it is just a refactor exercise that makes the code easier to follow and more readable.

I can think of adding async/await in future for less boilerplate code an more readability.., but for now it is just what it is.

It's been tested against tryit.jssip.net successfully.

would you give it a quick review whenever you have some time @ibc?