### PR TITLE
RTCSession: custom local description trigger support

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1877,24 +1877,40 @@ module.exports = class RTCSession extends EventEmitter
         // Add 'pc.onicencandidate' event handler to resolve on last candidate.
         return new Promise((resolve) =>
         {
+          let finished = false;
           let listener;
+
+          const ready = () =>
+          {
+            connection.removeEventListener('icecandidate', listener);
+
+            finished = true;
+            this._rtcReady = true;
+
+            const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
+
+            debug('emit "sdp"');
+
+            this.emit('sdp', e);
+
+            resolve(e.sdp);
+          };
 
           connection.addEventListener('icecandidate', listener = (event) =>
           {
             const candidate = event.candidate;
 
-            if (! candidate)
+            if (candidate)
             {
-              connection.removeEventListener('icecandidate', listener);
-              this._rtcReady = true;
+              this.emit('icecandidate', {
+                candidate,
+                ready
+              });
+            }
 
-              const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
-
-              debug('emit "sdp"');
-
-              this.emit('sdp', e);
-
-              resolve(e.sdp);
+            else if (! finished)
+            {
+              ready();
             }
           });
         });


### PR DESCRIPTION
```
Provide a new event 'icecandidate' which allows the user to indicate
JsSIP that the local description is ready to be sent regardless of
whether the acknowledged ICE candidate is the last one notified by
RTCPeerConection or not.
```

This prevents the hack of setting a gathering timeout in JsSIP and provides more flexibility on the decision of triggering the local description.