### PR TITLE
Add missing payload on 'RTCSession:getusermediafailed' event

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -2545,7 +2545,7 @@ module.exports = class RTCSession extends EventEmitter
 
               debugerror('emit "getusermediafailed" [error:%o]', error);
 
-              this.emit('getusermediafailed');
+              this.emit('getusermediafailed', error);
 
               throw error;
             });


### PR DESCRIPTION
Added missing error parameter on one of the two getusermediafailed-event emits in RTCSession.js