### PR TITLE
feat: handle unsubscribe notify event

### DIFF
--- a/lib/UA.js
+++ b/lib/UA.js
@@ -666,13 +666,8 @@ module.exports = class UA extends EventEmitter
            */
           break;
         case JsSIP_C.NOTIFY:
-          /**
-           * receive new sip event
-           */
-          this.emit('sipEvent', {
-            event: request.event.event,
-            body: request.body
-          });
+          // receive new sip event
+          this.emit('sipEvent', request);
           request.reply(200);
           break;
         default:

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -666,7 +666,7 @@ module.exports = class UA extends EventEmitter
            */
           break;
         case JsSIP_C.NOTIFY:
-          // receive new sip event
+          // Receive new sip event.
           this.emit('sipEvent', request);
           request.reply(200);
           break;

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -669,7 +669,7 @@ module.exports = class UA extends EventEmitter
           /**
            * receive new sip event
            */
-          this.emit('newSipEvent', {
+          this.emit('sipEvent', {
             event: request.event.event,
             body: request.body
           });

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -665,6 +665,16 @@ module.exports = class UA extends EventEmitter
            * and without To tag.
            */
           break;
+        case JsSIP_C.NOTIFY:
+          /**
+           * receive new sip event
+           */
+          this.emit('newSipEvent', {
+            event: request.event.event,
+            body: request.body
+          });
+          request.reply(200);
+          break;
         default:
           request.reply(405);
           break;


### PR DESCRIPTION
Here a PR to manage the NOTIFY event.

At the moment is ignored, but Asterisk send a NOTIFY `message-summary` after registered.

The UA emit the new event `sipEvent` with the event and the body to keep it simple.

Should also solve #538 