### PR TITLE
Fix: switches to tracks from deprecated stream API

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -676,7 +676,10 @@ module.exports = class RTCSession extends EventEmitter
         this._localMediaStream = stream;
         if (stream)
         {
-          this._connection.addStream(stream);
+          stream.getTracks().forEach((track) =>
+          {
+            this._connection.addTrack(track, stream);
+          });
         }
       })
       // Set remote description.
@@ -2562,7 +2565,10 @@ module.exports = class RTCSession extends EventEmitter
 
         if (stream)
         {
-          this._connection.addStream(stream);
+          stream.getTracks().forEach((track) =>
+          {
+            this._connection.addTrack(track, stream);
+          });
         }
 
         // TODO: should this be triggered here?
@@ -3315,31 +3321,27 @@ module.exports = class RTCSession extends EventEmitter
 
   _toogleMuteAudio(mute)
   {
-    const streams = this._connection.getLocalStreams();
-
-    for (const stream of streams)
+    const senders = this._connection.getSenders().filter((sender) =>
     {
-      const tracks = stream.getAudioTracks();
+      return sender.track && sender.track.kind === 'audio';
+    });
 
-      for (const track of tracks)
-      {
-        track.enabled = !mute;
-      }
+    for (const sender of senders)
+    {
+      sender.track.enabled = !mute;
     }
   }
 
   _toogleMuteVideo(mute)
   {
-    const streams = this._connection.getLocalStreams();
-
-    for (const stream of streams)
+    const senders = this._connection.getSenders().filter((sender) =>
     {
-      const tracks = stream.getVideoTracks();
+      return sender.track && sender.track.kind === 'video';
+    });
 
-      for (const track of tracks)
-      {
-        track.enabled = !mute;
-      }
+    for (const sender of senders)
+    {
+      sender.track.enabled = !mute;
     }
   }
 


### PR DESCRIPTION
addStream/getLocalStreams usage has been completely removed. The rationale for this is that if someone needs to support an older browser, they can use webrtc-adapter because it provides the necessary shims.

We have been using this fix without any issues for some time. 