### PR TITLE
Add back support for deprecated stream method

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -485,6 +485,24 @@ module.exports = class RTCSession extends EventEmitter
     this._progress('local', null);
   }
 
+   /**
+   * Add stream to connection.
+   */
+  _addStream(stream) {
+    if (stream)
+    {
+      if(this._connection.addTrack) {
+        stream.getTracks().forEach((track) =>
+        {
+          this._connection.addTrack(track, stream);
+        });
+      } else {
+        // Support deprecated method in older browsers
+        this._connection.addStream(stream);	
+      }
+    }
+  }
+
   /**
    * Answer the call.
    */
@@ -674,13 +692,7 @@ module.exports = class RTCSession extends EventEmitter
         }
 
         this._localMediaStream = stream;
-        if (stream)
-        {
-          stream.getTracks().forEach((track) =>
-          {
-            this._connection.addTrack(track, stream);
-          });
-        }
+        this._addStream(stream);
       })
       // Set remote description.
       .then(() =>
@@ -2562,14 +2574,7 @@ module.exports = class RTCSession extends EventEmitter
         }
 
         this._localMediaStream = stream;
-
-        if (stream)
-        {
-          stream.getTracks().forEach((track) =>
-          {
-            this._connection.addTrack(track, stream);
-          });
-        }
+        this._addStream(stream);
 
         // TODO: should this be triggered here?
         this._connecting(this._request);
@@ -3329,30 +3334,37 @@ module.exports = class RTCSession extends EventEmitter
     }
   }
 
+
+  _toggleMute(mute, kind) {
+    if (this._connection.getSenders) {
+      const senders = this._connection.getSenders().filter((sender) =>
+      {
+        return sender.track && sender.track.kind === kind;
+      });
+  
+      for (const sender of senders)
+      {
+        sender.track.enabled = !mute;
+      }
+    } else {
+      const streams = this._connection.getLocalStreams();
+      for (const stream of streams) {
+        const tracks = kind == 'audio' ? stream.getAudioTracks() : stream.getVideoTracks();
+        for (const track of tracks) {
+          track.enabled = !mute;
+        }
+      }
+    }
+  }
+
   _toggleMuteAudio(mute)
   {
-    const senders = this._connection.getSenders().filter((sender) =>
-    {
-      return sender.track && sender.track.kind === 'audio';
-    });
-
-    for (const sender of senders)
-    {
-      sender.track.enabled = !mute;
-    }
+    this._toggleMute(mute, 'audio');
   }
 
   _toggleMuteVideo(mute)
   {
-    const senders = this._connection.getSenders().filter((sender) =>
-    {
-      return sender.track && sender.track.kind === 'video';
-    });
-
-    for (const sender of senders)
-    {
-      sender.track.enabled = !mute;
-    }
+    this._toggleMute(mute, 'video');
   }
 
   _newRTCSession(originator, request)


### PR DESCRIPTION
- Add support for deprecated method in older browsers (older versions of chrome/ electron don’t support the addTrack function)
- DRYer code