### PR TITLE
use sdpSemantics: 'plan-b'

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1787,7 +1787,16 @@ module.exports = class RTCSession extends EventEmitter
 
   _createRTCConnection(pcConfig, rtcConstraints)
   {
-    this._connection = new RTCPeerConnection(pcConfig, rtcConstraints);
+    this._connection = new RTCPeerConnection(
+      Object.assign(
+        {},
+        pcConfig,
+        {
+          sdpSemantics : 'plan-b'
+        }
+      ),
+      rtcConstraints
+    );
 
     this._connection.addEventListener('iceconnectionstatechange', () =>
     {


### PR DESCRIPTION
to support Chrome 72
fix for sdpSemantics: 'unified-plan' in process