### PR TITLE
Fix NameAddrHeader display_name handling

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -173,14 +173,7 @@ const checks = {
 
     display_name(display_name)
     {
-      if (Grammar.parse(`"${display_name}"`, 'display_name') === -1)
-      {
-        return;
-      }
-      else
-      {
-        return display_name;
-      }
+      return display_name;
     },
 
     instance_id(instance_id)

--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -2715,7 +2715,12 @@ module.exports = (function(){
         }
         if (result0 !== null) {
           result0 = (function(offset) {
-                                return input.substring(pos-1, offset+1); })(pos0);
+                          var trimmed = input
+                              .substring(pos, offset)
+                              .trim();
+                          return trimmed
+                              .substring(1, trimmed.length - 1) // remove outer quotes
+                              .replace(/\\([\x00-\x09\x0b-\x0c\x0e-\x7f])/g, '$1'); })(pos0);
         }
         if (result0 === null) {
           pos = pos0;
@@ -8048,15 +8053,17 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 === null) {
-          result0 = parse_quoted_string();
+          result0 = parse_quoted_string_clean();
         }
         if (result0 !== null) {
           result0 = (function(offset, display_name) {
-                                display_name = input.substring(pos, offset).trim();
-                                if (display_name[0] === '\"') {
-                                  display_name = display_name.substring(1, display_name.length-1);
-                                }
-                                data.display_name = display_name; })(pos0, result0);
+                                if (typeof display_name === 'string') { // quoted_string_clean
+                                    data.display_name = display_name;
+                                } else { // token ( LWS token )*
+                                    data.display_name = display_name[1].reduce(function(acc, cur) {
+                                        return acc + cur[0] + cur[1];
+                                    }, display_name[0]);
+                                }})(pos0, result0);
         }
         if (result0 === null) {
           pos = pos0;

--- a/lib/Grammar.pegjs
+++ b/lib/Grammar.pegjs
@@ -89,7 +89,13 @@ quoted_string = SWS DQUOTE ( qdtext / quoted_pair )* DQUOTE {
                   return input.substring(pos, offset); }
 
 quoted_string_clean = SWS DQUOTE ( qdtext / quoted_pair )* DQUOTE {
-                        return input.substring(pos-1, offset+1); }
+                  var trimmed = input
+                      .substring(pos, offset)
+                      .trim();
+
+                  return trimmed
+                      .substring(1, trimmed.length - 1) // remove outer quotes
+                      .replace(/\\([\x00-\x09\x0b-\x0c\x0e-\x7f])/g, '$1'); } // unquote contents
 
 qdtext  = LWS / "\x21" / [\x23-\x5B] / [\x5D-\x7E] / UTF8_NONASCII
 
@@ -426,13 +432,16 @@ name_addr           = ( display_name )? LAQUOT SIP_URI RAQUOT
 
 addr_spec           = SIP_URI_noparams
 
-display_name        = display_name: (token ( LWS token )* / quoted_string) {
-                        display_name = input.substring(pos, offset).trim();
-                        if (display_name[0] === '\"') {
-                          display_name = display_name.substring(1, display_name.length-1);
-                        }
-                        data.display_name = display_name; }
+display_name        = display_name: (token ( LWS token )* / quoted_string_clean) {
+                        if (typeof display_name === 'string') { // quoted_string_clean
+                            data.display_name = display_name;
+                        } else { // token ( LWS token )*
+                            data.display_name = display_name[1].reduce(function(acc, cur) {
+                                return acc + cur[0] + cur[1];
+                            }, display_name[0]);
+                        }}
                         // The previous rule is corrected from RFC3261
+                        // See https://www.rfc-editor.org/errata/eid5598
 
 contact_params      = c_p_q / c_p_expires / contact_extension
 

--- a/lib/NameAddrHeader.js
+++ b/lib/NameAddrHeader.js
@@ -108,9 +108,16 @@ module.exports = class NameAddrHeader
       JSON.parse(JSON.stringify(this._parameters)));
   }
 
+  _quote(str)
+  {
+    return str
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+  }
+
   toString()
   {
-    let body = this._display_name ? `"${this._display_name}" ` : '';
+    let body = this._display_name ? `"${this._quote(this._display_name)}" ` : '';
 
     body += `<${this._uri.toString()}>`;
 

--- a/lib/NameAddrHeader.js
+++ b/lib/NameAddrHeader.js
@@ -32,7 +32,7 @@ module.exports = class NameAddrHeader
     // Initialize parameters.
     this._uri = uri;
     this._parameters = {};
-    this._display_name = display_name;
+    this.display_name = display_name;
 
     for (const param in parameters)
     {
@@ -110,7 +110,7 @@ module.exports = class NameAddrHeader
 
   toString()
   {
-    let body = (this._display_name || this._display_name === 0) ? `"${this._display_name}" ` : '';
+    let body = this._display_name ? `"${this._display_name}" ` : '';
 
     body += `<${this._uri.toString()}>`;
 

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -14,6 +14,7 @@ const RTCSession_DTMF = require('./RTCSession/DTMF');
 const RTCSession_Info = require('./RTCSession/Info');
 const RTCSession_ReferNotifier = require('./RTCSession/ReferNotifier');
 const RTCSession_ReferSubscriber = require('./RTCSession/ReferSubscriber');
+const URI = require('./URI');
 const debug = require('debug')('JsSIP:RTCSession');
 const debugerror = require('debug')('JsSIP:ERROR:RTCSession');
 
@@ -344,7 +345,7 @@ module.exports = class RTCSession extends EventEmitter
     if (anonymous)
     {
       requestParams.from_display_name = 'Anonymous';
-      requestParams.from_uri = 'sip:anonymous@anonymous.invalid';
+      requestParams.from_uri = new URI('sip', 'anonymous', 'anonymous.invalid');
 
       extraHeaders.push(`P-Preferred-Identity: ${this._ua.configuration.uri.toString()}`);
       extraHeaders.push('Privacy: id');

--- a/lib/SIPMessage.js
+++ b/lib/SIPMessage.js
@@ -54,32 +54,33 @@ class OutgoingRequest
     this.setHeader('max-forwards', JsSIP_C.MAX_FORWARDS);
 
     // To
-    let to = (params.to_display_name || params.to_display_name === 0) ? `"${params.to_display_name}" ` : '';
+    const to_uri = params.to_uri || ruri;
+    const to_params = params.to_tag ? { tag: params.to_tag } : null;
+    const to_display_name = typeof params.to_display_name !== 'undefined' ? params.to_display_name : null;
 
-    to += `<${params.to_uri || ruri}>`;
-    to += params.to_tag ? `;tag=${params.to_tag}` : '';
-    this.to = NameAddrHeader.parse(to);
-    this.setHeader('to', to);
+    this.to = new NameAddrHeader(to_uri, to_display_name, to_params);
+    this.setHeader('to', this.to.toString());
 
     // From.
-    let from;
+    const from_uri = params.from_uri || ua.configuration.uri;
+    const from_params = { tag: params.from_tag || Utils.newTag() };
+    let display_name;
 
-    if (params.from_display_name || params.from_display_name === 0)
+    if (typeof params.from_display_name !== 'undefined')
     {
-      from = `"${params.from_display_name}" `;
+      display_name = params.from_display_name;
     }
     else if (ua.configuration.display_name)
     {
-      from = `"${ua.configuration.display_name}" `;
+      display_name = ua.configuration.display_name;
     }
     else
     {
-      from = '';
+      display_name = null;
     }
-    from += `<${params.from_uri || ua.configuration.uri}>;tag=`;
-    from += params.from_tag || Utils.newTag();
-    this.from = NameAddrHeader.parse(from);
-    this.setHeader('from', from);
+
+    this.from = new NameAddrHeader(from_uri, display_name, from_params);
+    this.setHeader('from', this.from.toString());
 
     // Call-ID.
     const call_id = params.call_id ||
@@ -760,4 +761,3 @@ module.exports = {
   IncomingRequest,
   IncomingResponse
 };
-

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -8,7 +8,6 @@ const Transport = require('./Transport');
 const Utils = require('./Utils');
 const Exceptions = require('./Exceptions');
 const URI = require('./URI');
-const Grammar = require('./Grammar');
 const Parser = require('./Parser');
 const SIPMessage = require('./SIPMessage');
 const sanityCheck = require('./sanityCheck');
@@ -395,12 +394,6 @@ module.exports = class UA extends EventEmitter
       }
 
       case 'display_name': {
-        if (Grammar.parse(`"${value}"`, 'display_name') === -1)
-        {
-          debugerror('set() | wrong "display_name"');
-
-          return false;
-        }
         this._configuration.display_name = value;
         break;
       }

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -44,12 +44,14 @@ module.exports = {
 
   'parse NameAddr' : function(test)
   {
-    const data = '"Iñaki ðđøþ" <SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2>;QWE=QWE;ASd';
+    const data = ' "Iñaki ðđøþ foo \\"bar\\" \\\\\\\\ \\\\ \\\\d \\\\\\\\d \\\\\' \\\\\\"sdf\\\\\\"" ' +
+          '<SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2>;QWE=QWE;ASd';
+
     const name = JsSIP.NameAddrHeader.parse(data);
 
     // Parsed data.
     test.ok(name instanceof(JsSIP.NameAddrHeader));
-    test.strictEqual(name.display_name, 'Iñaki ðđøþ');
+    test.strictEqual(name.display_name, 'Iñaki ðđøþ foo "bar" \\\\ \\ \\d \\\\d \\\' \\"sdf\\"');
     test.strictEqual(name.hasParam('qwe'), true);
     test.strictEqual(name.hasParam('asd'), true);
     test.strictEqual(name.hasParam('nooo'), false);
@@ -81,6 +83,45 @@ module.exports = {
     test.strictEqual(name.toString(), '<sip:aliCE@versatica.com:6060;transport=tcp;foo=ABc;baz?X-Header-1=AaA1&X-Header-1=AAA2&X-Header-2=BbB>;qwe=QWE;asd');
     uri.user = 'Iñaki:PASSWD';
     test.strictEqual(uri.toAor(), 'sip:I%C3%B1aki:PASSWD@versatica.com');
+
+    test.done();
+  },
+
+  'parse NameAddr with token display_name' : function(test)
+  {
+    const data = 'Foo    Foo Bar\tBaz<SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2>;QWE=QWE;ASd';
+
+    const name = JsSIP.NameAddrHeader.parse(data);
+
+    // Parsed data.
+    test.ok(name instanceof(JsSIP.NameAddrHeader));
+    test.strictEqual(name.display_name, 'Foo Foo Bar Baz');
+
+    test.done();
+  },
+
+  'parse NameAddr with no space between DQUOTE and LAQUOT' : function(test)
+  {
+    const data = '"Foo"<SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2>;QWE=QWE;ASd';
+
+    const name = JsSIP.NameAddrHeader.parse(data);
+
+    // Parsed data.
+    test.ok(name instanceof(JsSIP.NameAddrHeader));
+    test.strictEqual(name.display_name, 'Foo');
+
+    test.done();
+  },
+
+  'parse NameAddr with no display_name' : function(test)
+  {
+    const data = '<SIP:%61liCE@versaTICA.Com:6060;TRansport=TCp;Foo=ABc;baz?X-Header-1=AaA1&X-Header-2=BbB&x-header-1=AAA2>;QWE=QWE;ASd';
+
+    const name = JsSIP.NameAddrHeader.parse(data);
+
+    // Parsed data.
+    test.ok(name instanceof(JsSIP.NameAddrHeader));
+    test.strictEqual(name.display_name, undefined);
 
     test.done();
   },


### PR DESCRIPTION
When dealing with NameAddress display names which contained double quotes, such as "John \"The Duke\" Wayne", we have identified several parser issues which prevented proper handling of such display names.

Specifically we identified the following issues:

a. Issues in quoted_string_clean rule:
1. The substring operation (`input.substring(pos-1, offset+1);`) to remove outer quotes returns incorrect results for strings that begin with SWS
2. Strings are not completely unescaped. The outer DQUOTES are removed but quoted_pair sequences are not unescaped.

b. Issues in display_name rule:
1. Quoted display_name is not properly unescaped since quoted_string rule is used.
2. display_name matching token `( LWS token )*` form is not converted to string

c. Issues in NameAddrHeader class: toString() method did not escape display_name

d. UA Config: option validation rejected valid display_name, such as "John \"The Duke\" Wayne".

e. OutgoingRequest: SIPMessage class was creating To and From headers via simple string manipulation and display_name was not properly escaped.

In general handling of quoted strings in display name was inconsistent with double quotes being escaped or passed through depending on the code path.

This pull request addresses all of these issues.

Please note:

1. Other portions of the parser that use the quoted_string rule are also broken because they are not escaped or unescaped, e.g. gen_param. These are not addressed by this pull request.
2. The logic that accepts the integer 0 as a display_name was preserved however it is unclear what purpose/use case it serves.