### PR TITLE
External timeout to stop ICE candidates gathering

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -102,6 +102,9 @@ module.exports = class RTCSession extends EventEmitter
       userNoAnswerTimer : null
     };
 
+    // Timeout for ICE gathering
+    this._iceGatheringTimeout = 0;
+
     // Session info.
     this._direction = null;
     this._local_identity = null;
@@ -276,6 +279,9 @@ module.exports = class RTCSession extends EventEmitter
 
     this._rtcOfferConstraints = rtcOfferConstraints;
     this._rtcAnswerConstraints = options.rtcAnswerConstraints || null;
+
+    // By defult we disable timeout
+    this._iceGatheringTimeout = options.iceGatheringTimeout || 0;
 
     this._data = options.data || this._data;
 
@@ -1888,9 +1894,14 @@ module.exports = class RTCSession extends EventEmitter
         {
           let finished = false;
           let listener;
+          let timer = null;
 
           const ready = () =>
           {
+            if (finished) {
+              return;
+            }
+
             connection.removeEventListener('icecandidate', listener);
 
             finished = true;
@@ -1905,9 +1916,25 @@ module.exports = class RTCSession extends EventEmitter
             resolve(e.sdp);
           };
 
+          // If waiting for candidate for long time - stop the gathering and continue as is
+          var timeout = function timeout() {
+            debug('candidate gathering timeout');
+            ready();
+          };
+
+          // Set timer to prevent very long candidate gathering
+          if (this._iceGatheringTimeout > 0) {
+            timer = setTimeout(timeout, this._iceGatheringTimeout);
+          }
+
           connection.addEventListener('icecandidate', listener = (event) =>
           {
             const candidate = event.candidate;
+
+            if (timer) {
+              clearTimeout(timer);
+              timer = null;
+            }
 
             if (candidate)
             {
@@ -1915,6 +1942,11 @@ module.exports = class RTCSession extends EventEmitter
                 candidate,
                 ready
               });
+
+              // Set timer to prevent very long candidate gathering
+              if (this._iceGatheringTimeout > 0) {
+                timer = setTimeout(timeout, this._iceGatheringTimeout);
+              }
             }
 
             else if (! finished)


### PR DESCRIPTION
When client has many TURN/STUN servers ICE gathering state should take a
very long time. We should limit this by external timeout for speedup
connection time.

By default this timeout disabled.