### PR TITLE
Fix handling of 'icecandidate' event

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1913,7 +1913,7 @@ module.exports = class RTCSession extends EventEmitter
             {
               this.emit('icecandidate', {
                 candidate,
-                ready
+                ready()
               });
             }
 


### PR DESCRIPTION
Problem:
When defining ice servers in the pcConfig in ua.call the invite is
not sent before the 'icegatheringstatechange' event is received
with state 'complete'. On Chrome this takes 40 seconds while the
'icecandidate' events are received immediately.

It seems like commit 7e3fbe715c2cbdb69e53b6598d5db92d7dd3fc73 was
supposed to fix this by calling 'ready' before the ice gathering
is complete. However, this code does not work.

Solution:
Pass 'ready()' instead of 'ready' in the second argument of the
'icecandidate' event.