### PR TITLE
Fix crash in Chromium 61

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -679,7 +679,10 @@ module.exports = class RTCSession extends EventEmitter
         {
           stream.getTracks().forEach((track) =>
           {
-            this._connection.addTrack(track, stream);
+            if (typeof this._connection.addTrack == "function")
+            {
+              this._connection.addTrack(track, stream);
+            }
           });
         }
       })
@@ -2568,7 +2571,10 @@ module.exports = class RTCSession extends EventEmitter
         {
           stream.getTracks().forEach((track) =>
           {
-            this._connection.addTrack(track, stream);
+            if (typeof this._connection.addTrack == "function")
+            {
+              this._connection.addTrack(track, stream);
+            }
           });
         }
 


### PR DESCRIPTION
When i try to answer a call in Chromium 61, an exception is raised by a function undefined.

I used this fix to work around the issue, it's working nicely