### PR TITLE
Move connection recovery defaults to Constants

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -36,8 +36,8 @@ exports.settings = {
 
   // Connection options.
   sockets                          : null,
-  connection_recovery_max_interval : null,
-  connection_recovery_min_interval : null,
+  connection_recovery_max_interval : JsSIP_C.CONNECTION_RECOVERY_MAX_INTERVAL,
+  connection_recovery_min_interval : JsSIP_C.CONNECTION_RECOVERY_MIN_INTERVAL,
 
   /*
    * Host address.

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -147,5 +147,8 @@ module.exports = {
   ACCEPTED_BODY_TYPES : 'application/sdp, application/dtmf-relay',
   MAX_FORWARDS        : 69,
   SESSION_EXPIRES     : 90,
-  MIN_SESSION_EXPIRES : 60
+  MIN_SESSION_EXPIRES : 60,
+
+  CONNECTION_RECOVERY_MAX_INTERVAL: 30,
+  CONNECTION_RECOVERY_MIN_INTERVAL: 2
 };

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -1,6 +1,7 @@
 const Socket = require('./Socket');
 const debug = require('debug')('JsSIP:Transport');
 const debugerror = require('debug')('JsSIP:ERROR:Transport');
+const JsSIP_C = require('./Constants');
 
 debugerror.log = console.warn.bind(console);
 
@@ -19,8 +20,8 @@ const C = {
 
   // Recovery options.
   recovery_options : {
-    min_interval : 2, // minimum interval in seconds between recover attempts
-    max_interval : 30 // maximum interval in seconds between recover attempts
+    min_interval : JsSIP_C.CONNECTION_RECOVERY_MIN_INTERVAL, // minimum interval in seconds between recover attempts
+    max_interval : JsSIP_C.CONNECTION_RECOVERY_MAX_INTERVAL // maximum interval in seconds between recover attempts
   }
 };
 


### PR DESCRIPTION
Use these constants in the initial configuration settings.

This fixes the situation where if the max backoff limit is `null` when trying to reconnect the transport, the calculated backoff time is ignored and the reconnection attempt happens immediately.