### PR TITLE
Fix to "Offer in response to an INVITE no-sdp reflects remote hold state" #612

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -2063,7 +2063,11 @@ module.exports = class RTCSession extends EventEmitter
     if (!request.body)
     {
       this._late_sdp = true;
-
+      if (this._remoteHold) 
+      {
+        this._remoteHold = false;
+        this._onunhold('remote');
+      }
       this._connectionPromiseQueue = this._connectionPromiseQueue
         .then(() => this._createLocalDescription('offer', this._rtcOfferConstraints))
         .then((sdp) =>


### PR DESCRIPTION
If we are put on-hold by the remote, and then we receive a INVITE without sdp, we generate an offer reflecting the remotes request.
[RFC 6337](https://tools.ietf.org/html/rfc6337#section-5.1) states:

    A UA should send an offer that indicates what it, and its user, are
    interested in using/doing at that time, without regard for what the
    other party in the call may have indicated previously. This is the
    case even when the offer is sent in response to an INVITE or re-
    INVITE that contains no offer.

This is a fairly common sequence for performing call transfers, and as it stands it results in the client not sending audio.

If the remote still wants us to be on-hold, it will indicate this in its answer sdp.