### PR TITLE
sanity: merged request check enhancement

### DIFF
--- a/lib/sanityCheck.js
+++ b/lib/sanityCheck.js
@@ -1,5 +1,6 @@
 const JsSIP_C = require('./Constants');
 const SIPMessage = require('./SIPMessage');
+const Transactions = require('./Transactions');
 const Utils = require('./Utils');
 const debug = require('debug')('JsSIP:sanityCheck');
 
@@ -153,7 +154,8 @@ function rfc3261_8_2_2_2()
         if (Object.prototype.hasOwnProperty.call(ua._transactions.ist, transaction))
         {
           tr = ua._transactions.ist[transaction];
-          if (tr.request.from_tag === fromTag &&
+          if (tr.request.state < Transactions.C.STATUS_TERMINATED &&
+	      tr.request.from_tag === fromTag &&
               tr.request.call_id === call_id &&
               tr.request.cseq === cseq)
           {
@@ -184,7 +186,8 @@ function rfc3261_8_2_2_2()
       if (Object.prototype.hasOwnProperty.call(ua._transactions.nist, transaction))
       {
         tr = ua._transactions.nist[transaction];
-        if (tr.request.from_tag === fromTag &&
+        if (tr.request.state < Transactions.C.STATUS_COMPLETED &&
+	    tr.request.from_tag === fromTag &&
             tr.request.call_id === call_id &&
             tr.request.cseq === cseq)
         {


### PR DESCRIPTION
Do not do merged request check if INVITE transaction is already confirmed or non-INVITE transaction is already completed.