### PR TITLE
Fix to allow initial INVITE no SDP/offer

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -500,6 +500,7 @@ module.exports = class RTCSession extends EventEmitter
     const pcConfig = options.pcConfig || { iceServers: [] };
     const rtcConstraints = options.rtcConstraints || null;
     const rtcAnswerConstraints = options.rtcAnswerConstraints || null;
+    const rtcOfferConstraints = options.rtcOfferConstraints || {};
 
     let tracks;
     let peerHasAudioLine = false;
@@ -617,13 +618,13 @@ module.exports = class RTCSession extends EventEmitter
     }
 
     // Don't ask for audio if the incoming offer has no audio section.
-    if (!mediaStream && !peerHasAudioLine && !options.rtcOfferConstraints)
+    if (!mediaStream && !peerHasAudioLine && !rtcOfferConstraints.offerToReceiveAudio)
     {
       mediaConstraints.audio = false;
     }
 
     // Don't ask for video if the incoming offer has no video section.
-    if (!mediaStream && !peerHasVideoLine && !options.rtcOfferConstraints)
+    if (!mediaStream && !peerHasVideoLine && !rtcOfferConstraints.offerToReceiveVideo)
     {
       mediaConstraints.video = false;
     }

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -617,13 +617,13 @@ module.exports = class RTCSession extends EventEmitter
     }
 
     // Don't ask for audio if the incoming offer has no audio section.
-    if (!mediaStream && !peerHasAudioLine)
+    if (!mediaStream && !peerHasAudioLine && options.rtcOfferConstraints === undefined)
     {
       mediaConstraints.audio = false;
     }
 
     // Don't ask for video if the incoming offer has no video section.
-    if (!mediaStream && !peerHasVideoLine)
+    if (!mediaStream && !peerHasVideoLine && options.rtcOfferConstraints === undefined)
     {
       mediaConstraints.video = false;
     }

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -617,13 +617,13 @@ module.exports = class RTCSession extends EventEmitter
     }
 
     // Don't ask for audio if the incoming offer has no audio section.
-    if (!mediaStream && !peerHasAudioLine && options.rtcOfferConstraints === undefined)
+    if (!mediaStream && !peerHasAudioLine && !options.rtcOfferConstraints)
     {
       mediaConstraints.audio = false;
     }
 
     // Don't ask for video if the incoming offer has no video section.
-    if (!mediaStream && !peerHasVideoLine && options.rtcOfferConstraints === undefined)
+    if (!mediaStream && !peerHasVideoLine && !options.rtcOfferConstraints)
     {
       mediaConstraints.video = false;
     }


### PR DESCRIPTION
Allow jssip to respond to INVITE no SDP with a 'a=sendrecv' offer if the user has included rtcOfferConstraints in the session.answer() method.