### PR TITLE
clone mediaConstraints options

### DIFF
--- a/lib/Dialog.js
+++ b/lib/Dialog.js
@@ -145,7 +145,7 @@ module.exports = class Dialog
   sendRequest(method, options = {})
   {
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const body = options.body || null;
     const request = this._createRequest(method, extraHeaders, body);
 

--- a/lib/Message.js
+++ b/lib/Message.js
@@ -60,7 +60,7 @@ module.exports = class Message extends EventEmitter
 
     // Get call options.
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const contentType = options.contentType || 'text/plain';
 
     // Set event handlers.

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -266,11 +266,14 @@ module.exports = class RTCSession extends EventEmitter
     debug('connect()');
 
     const originalTarget = target;
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const mediaConstraints = options.mediaConstraints || { audio: true, video: true };
+    const mediaConstraints = Utils.cloneObject(options.mediaConstraints, {
+      audio : true,
+      video : false
+    });
     const mediaStream = options.mediaStream || null;
-    const pcConfig = options.pcConfig || { iceServers: [] };
+    const pcConfig = Utils.cloneObject(options.pcConfig, { iceServers: [] });
     const rtcConstraints = options.rtcConstraints || null;
     const rtcOfferConstraints = options.rtcOfferConstraints || null;
 
@@ -497,7 +500,7 @@ module.exports = class RTCSession extends EventEmitter
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
     const mediaConstraints = Utils.cloneObject(options.mediaConstraints);
     const mediaStream = options.mediaStream || null;
-    const pcConfig = options.pcConfig || { iceServers: [] };
+    const pcConfig = Utils.cloneObject(options.pcConfig, { iceServers: [] });
     const rtcConstraints = options.rtcConstraints || null;
     const rtcAnswerConstraints = options.rtcAnswerConstraints || null;
 
@@ -2825,7 +2828,7 @@ module.exports = class RTCSession extends EventEmitter
     debug('sendReinvite()');
 
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const rtcOfferConstraints = options.rtcOfferConstraints ||
       this._rtcOfferConstraints || null;
 
@@ -2956,7 +2959,7 @@ module.exports = class RTCSession extends EventEmitter
     debug('sendUpdate()');
 
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const rtcOfferConstraints = options.rtcOfferConstraints ||
       this._rtcOfferConstraints || null;
     const sdpOffer = options.sdpOffer || false;

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -495,7 +495,7 @@ module.exports = class RTCSession extends EventEmitter
 
     const request = this._request;
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const mediaConstraints = options.mediaConstraints || {};
+    const mediaConstraints = Utils.cloneObject(options.mediaConstraints);
     const mediaStream = options.mediaStream || null;
     const pcConfig = options.pcConfig || { iceServers: [] };
     const rtcConstraints = options.rtcConstraints || null;

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -270,7 +270,7 @@ module.exports = class RTCSession extends EventEmitter
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
     const mediaConstraints = Utils.cloneObject(options.mediaConstraints, {
       audio : true,
-      video : false
+      video : true
     });
     const mediaStream = options.mediaStream || null;
     const pcConfig = Utils.cloneObject(options.pcConfig, { iceServers: [] });

--- a/lib/RTCSession/DTMF.js
+++ b/lib/RTCSession/DTMF.js
@@ -56,7 +56,7 @@ module.exports = class DTMF extends EventEmitter
 
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
 
-    this.eventHandlers = options.eventHandlers || {};
+    this.eventHandlers = Utils.cloneObject(options.eventHandlers);
 
     // Check tone type.
     if (typeof tone === 'string')

--- a/lib/RTCSession/ReferSubscriber.js
+++ b/lib/RTCSession/ReferSubscriber.js
@@ -24,7 +24,7 @@ module.exports = class ReferSubscriber extends EventEmitter
     debug('sendRefer()');
 
     const extraHeaders = Utils.cloneArray(options.extraHeaders);
-    const eventHandlers = options.eventHandlers || {};
+    const eventHandlers = Utils.cloneObject(options.eventHandlers);
 
     // Set event handlers.
     for (const event in eventHandlers)

--- a/lib/SIPMessage.js
+++ b/lib/SIPMessage.js
@@ -25,7 +25,7 @@ class OutgoingRequest
       return null;
     }
 
-    params = params || {};
+    params = Utils.cloneObject(params);
 
     this.ua = ua;
     this.headers = {};

--- a/lib/SIPMessage.js
+++ b/lib/SIPMessage.js
@@ -25,7 +25,7 @@ class OutgoingRequest
       return null;
     }
 
-    params = Utils.cloneObject(params);
+    params = params || {};
 
     this.ua = ua;
     this.headers = {};

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -546,7 +546,7 @@ exports.cloneArray = (array) =>
   return (array && array.slice()) || [];
 };
 
-exports.cloneObject = (obj) =>
+exports.cloneObject = (obj, fallback = {}) =>
 {
-  return (obj && Object.assign({}, obj)) || {};
+  return (obj && Object.assign({}, obj)) || fallback;
 };

--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -545,3 +545,8 @@ exports.cloneArray = (array) =>
 {
   return (array && array.slice()) || [];
 };
+
+exports.cloneObject = (obj) =>
+{
+  return (obj && Object.assign({}, obj)) || {};
+};


### PR DESCRIPTION
otherwise an error is thrown trying to assign to a frozen object and the value is already set.

For example if sending options:

`{ mediaConstraints: { audio: true, video: false }}`

This code block throws an error:

```
// Don't ask for video if the incoming offer has no video section.
if (!mediaStream && !peerHasVideoLine)
{
    mediaConstraints.video = false;
}
```