### PR TITLE
Force gather candidates when iceRestart is true

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1903,7 +1903,7 @@ module.exports = class RTCSession extends EventEmitter
       .then(() =>
       {
         // Resolve right away if 'pc.iceGatheringState' is 'complete'.
-        if (connection.iceGatheringState === 'complete')
+        if (connection.iceGatheringState === 'complete' && (!constraints || !constraints.iceRestart))
         {
           this._rtcReady = true;
 


### PR DESCRIPTION
Hello,

Before I describe the pull request, I want to thank you for the good work on the project JsSIP.

I had some problems with network switching (eg: between wireless networks), when I try to use the next constraint: iceRestart true .
I notice the SDP was recreated without ice candidates, because the ICE Candidates Gathering was not executed, related to iceGatheringState === "complete"
This issue is similar to last scenario described at https://github.com/versatica/JsSIP/issues/499.
So I created an exception when there is constraint iceRestart: true, to continue to execution of ICE Candidates Gathering.
This commit solve the issue.

Thanks for the attention and I will appreciate some feedback/guidance .


