### PR TITLE
Fixed parsing `rport` in `Via` header (#642).

### DIFF
--- a/lib/Grammar.js
+++ b/lib/Grammar.js
@@ -11135,7 +11135,7 @@ module.exports = (function(){
       }
       function parse_response_port() {
         var result0, result1, result2, result3;
-        var pos0, pos1, pos2;
+        var pos0, pos1;
         pos0 = pos;
         pos1 = pos;
         if (input.substr(pos, 5).toLowerCase() === "rport") {
@@ -11148,7 +11148,6 @@ module.exports = (function(){
           }
         }
         if (result0 !== null) {
-          pos2 = pos;
           result1 = parse_EQUAL();
           if (result1 !== null) {
             result2 = [];
@@ -11158,18 +11157,11 @@ module.exports = (function(){
               result3 = parse_DIGIT();
             }
             if (result2 !== null) {
-              result1 = [result1, result2];
+              result0 = [result0, result1, result2];
             } else {
-              result1 = null;
-              pos = pos2;
+              result0 = null;
+              pos = pos1;
             }
-          } else {
-            result1 = null;
-            pos = pos2;
-          }
-          result1 = result1 !== null ? result1 : "";
-          if (result1 !== null) {
-            result0 = [result0, result1];
           } else {
             result0 = null;
             pos = pos1;
@@ -11179,9 +11171,9 @@ module.exports = (function(){
           pos = pos1;
         }
         if (result0 !== null) {
-          result0 = (function(offset) {
+          result0 = (function(offset, response_port) {
                               if(typeof response_port !== 'undefined')
-                                data.rport = response_port.join(''); })(pos0);
+                                data.rport = parseInt(response_port.join('')); })(pos0, result0[2]);
         }
         if (result0 === null) {
           pos = pos0;

--- a/lib/Grammar.pegjs
+++ b/lib/Grammar.pegjs
@@ -796,9 +796,9 @@ via_received      = "received"i EQUAL via_received: (IPv4address / IPv6address) 
 via_branch        = "branch"i EQUAL via_branch: token {
                       data.branch = via_branch; }
 
-response_port     = "rport"i (EQUAL response_port: (DIGIT*) )? {
+response_port     = "rport"i EQUAL response_port: (DIGIT*) {
                       if(typeof response_port !== 'undefined')
-                        data.rport = response_port.join(''); }
+                        data.rport = parseInt(response_port.join('')); }
 
 via_extension     = generic_param
 

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -203,7 +203,7 @@ module.exports = {
 
   'parse Via' : function(test)
   {
-    const data = 'SIP /  3.0 \r\n / UDP [1:ab::FF]:6060 ;\r\n  BRanch=1234;Param1=Foo;paRAM2;param3=Bar';
+    const data = 'SIP /  3.0 \r\n / UDP [1:ab::FF]:6060 ;\r\n  BRanch=1234;rport=12345;Param1=Foo;paRAM2;param3=Bar';
     const via = JsSIP.Grammar.parse(data, 'Via');
 
     test.strictEqual(via.protocol, 'SIP');
@@ -212,6 +212,7 @@ module.exports = {
     test.strictEqual(via.host_type, 'IPv6');
     test.strictEqual(via.port, 6060);
     test.strictEqual(via.branch, '1234');
+    test.strictEqual(via.rport, 12345);
     test.deepEqual(via.params, { param1: 'Foo', param2: undefined, param3: 'Bar' });
 
     test.done();


### PR DESCRIPTION
Fixes #642.