### PR TITLE
Add a config parameter to set the session timer refresher in the first request sent by JsSip

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -25,9 +25,10 @@ exports.settings = {
   use_preloaded_route : false,
 
   // Session parameters.
-  session_timers                : true,
-  session_timers_refresh_method : JsSIP_C.UPDATE,
-  no_answer_timeout             : 60,
+  session_timers                 : true,
+  session_timers_refresh_method  : JsSIP_C.UPDATE,
+  session_timers_force_refresher : false,
+  no_answer_timeout              : 60,
 
   // Registration parameters.
   register         : true,
@@ -230,6 +231,14 @@ const checks = {
         {
           return method;
         }
+      }
+    },
+
+    session_timers_force_refresher(session_timers_force_refresher)
+    {
+      if (typeof session_timers_force_refresher === 'boolean')
+      {
+        return session_timers_force_refresher;
       }
     },
 

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -358,7 +358,7 @@ module.exports = class RTCSession extends EventEmitter
     extraHeaders.push('Content-Type: application/sdp');
     if (this._sessionTimers.enabled)
     {
-      extraHeaders.push(`Session-Expires: ${this._sessionTimers.defaultExpires}`);
+      extraHeaders.push(`Session-Expires: ${this._sessionTimers.defaultExpires}${this._ua.configuration.session_timers_force_refresher ? ';refresher=uac' : ''}`);
     }
 
     this._request = new SIPMessage.InitialOutgoingInviteRequest(


### PR DESCRIPTION
ATM, JsSIP support the SIP session timers, and works strictly according to the RFC, which gives preference to the UAS triggering the session refresh. However in environment where the WebRTC client is connected via a client-side only initiated connection, it makes sense to force JsSIP to be the refresher of session timer. All it takes is basically to add the "refresher=uac" parameter to the Session-Expires HF in the initial INVITE