### PR TITLE
Fixed missing progress event for empty provisional responses

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -2783,6 +2783,7 @@ module.exports = class RTCSession extends EventEmitter
 
         if (!response.body)
         {
+          this._progress('remote', response);
           break;
         }
 


### PR DESCRIPTION
The changes for release 3.5.9 have partly broken the RTCSession progress event, it is no longer fired for provisional responses without a body, e.g. 180 Ringing. According to the JsSIP documentation the progress event is fired "when receiving or generating a 1XX SIP class response (>100) to the INVITE request.", this includes empty provisional responses. My change fixes that. I rely on this event in order to trigger local ringback playback from a sound resource in case of missing early media.