### PR TITLE
Update UAConfiguration type definitions to current state

### DIFF
--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -32,6 +32,7 @@ export interface UAConfiguration {
   no_answer_timeout?: number;
   session_timers?: boolean;
   session_timers_refresh_method?: string;
+  session_timers_force_refresher?: boolean;
   password?: string;
   realm?: string;
   ha1?: string;

--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -23,6 +23,7 @@ export interface UAConfiguration {
   sockets: Socket | Socket[] | WeightedSocket[] ;
   uri: string;
   // optional parameters
+  authorization_jwt?: string;
   authorization_user?: string;
   connection_recovery_max_interval?: number;
   connection_recovery_min_interval?: number;


### PR DESCRIPTION
Multiple commits (5d54593f3bb1fb3e028597b71df9e13dbe5f4f99, 921b65c977e72f53a67b644069a5c617439a3002) extended the UA configuration but not to [the typescript type](https://github.com/versatica/JsSIP/blob/cd2a6216d040e04862cf4c4408db23c29745ae9c/lib/UA.d.ts).

This pull request adds the necessary type definitions.