### PR TITLE
Make authorization_jwt writable

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -8,11 +8,11 @@ const Exceptions = require('./Exceptions');
 // Default settings.
 exports.settings = {
   // SIP authentication.
-  authorization_jwt  : null,
   authorization_user : null,
   password           : null,
   realm              : null,
   ha1                : null,
+  authorization_jwt  : null,
 
   // SIP account.
   display_name : null,

--- a/lib/Config.js
+++ b/lib/Config.js
@@ -8,6 +8,7 @@ const Exceptions = require('./Exceptions');
 // Default settings.
 exports.settings = {
   // SIP authentication.
+  authorization_jwt  : null,
   authorization_user : null,
   password           : null,
   realm              : null,

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -355,6 +355,9 @@ module.exports = class UA extends EventEmitter
   {
     switch (parameter)
     {
+      case 'authorization_jwt':
+        return this._configuration.authorization_jwt;
+
       case 'authorization_user':
         return this._configuration.authorization_user;
 
@@ -379,6 +382,11 @@ module.exports = class UA extends EventEmitter
   {
     switch (parameter)
     {
+      case 'authorization_jwt': {
+        this._configuration.authorization_jwt = String(value);
+        break;
+      }
+
       case 'authorization_user': {
         this._configuration.authorization_user = String(value);
         break;
@@ -895,7 +903,7 @@ module.exports = class UA extends EventEmitter
 
     // Seal the configuration.
     const writable_parameters = [
-      'authorization_user', 'password', 'realm', 'ha1', 'display_name', 'register'
+      'authorization_jwt', 'authorization_user', 'password', 'realm', 'ha1', 'display_name', 'register'
     ];
 
     for (const parameter in this._configuration)
@@ -931,6 +939,7 @@ module.exports = class UA extends EventEmitter
           case 'registrar_server':
             debug(`- ${parameter}: ${this._configuration[parameter]}`);
             break;
+          case 'authorization_jwt':
           case 'password':
           case 'ha1':
             debug(`- ${parameter}: NOT SHOWN`);

--- a/lib/UA.js
+++ b/lib/UA.js
@@ -355,9 +355,6 @@ module.exports = class UA extends EventEmitter
   {
     switch (parameter)
     {
-      case 'authorization_jwt':
-        return this._configuration.authorization_jwt;
-
       case 'authorization_user':
         return this._configuration.authorization_user;
 
@@ -366,6 +363,9 @@ module.exports = class UA extends EventEmitter
 
       case 'ha1':
         return this._configuration.ha1;
+
+      case 'authorization_jwt':
+        return this._configuration.authorization_jwt;
 
       default:
         debugerror('get() | cannot get "%s" parameter in runtime', parameter);
@@ -382,11 +382,6 @@ module.exports = class UA extends EventEmitter
   {
     switch (parameter)
     {
-      case 'authorization_jwt': {
-        this._configuration.authorization_jwt = String(value);
-        break;
-      }
-
       case 'authorization_user': {
         this._configuration.authorization_user = String(value);
         break;
@@ -406,6 +401,11 @@ module.exports = class UA extends EventEmitter
         this._configuration.ha1 = String(value);
         // Delete the plain SIP password.
         this._configuration.password = null;
+        break;
+      }
+
+      case 'authorization_jwt': {
+        this._configuration.authorization_jwt = String(value);
         break;
       }
 
@@ -903,7 +903,7 @@ module.exports = class UA extends EventEmitter
 
     // Seal the configuration.
     const writable_parameters = [
-      'authorization_jwt', 'authorization_user', 'password', 'realm', 'ha1', 'display_name', 'register'
+      'authorization_user', 'password', 'realm', 'ha1', 'authorization_jwt', 'display_name', 'register'
     ];
 
     for (const parameter in this._configuration)
@@ -939,9 +939,9 @@ module.exports = class UA extends EventEmitter
           case 'registrar_server':
             debug(`- ${parameter}: ${this._configuration[parameter]}`);
             break;
-          case 'authorization_jwt':
           case 'password':
           case 'ha1':
+          case 'authorization_jwt':
             debug(`- ${parameter}: NOT SHOWN`);
             break;
           default:


### PR DESCRIPTION
Allows to set the `authorization_jwt` in the UA-config during runtime.
This is necessary for short-lived JWTs.