### PR TITLE
close() function close media stream even if session is in terminated state

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1690,6 +1690,14 @@ module.exports = class RTCSession extends EventEmitter
   {
     debug('close()');
 
+    // Close local MediaStream if it was not given by the user.
+    if (this._localMediaStream && this._localMediaStreamLocallyGenerated)
+    {
+      debug('close() | closing local MediaStream');
+
+      Utils.closeMediaStream(this._localMediaStream);
+    }
+
     if (this._status === C.STATUS_TERMINATED)
     {
       return;
@@ -1708,14 +1716,6 @@ module.exports = class RTCSession extends EventEmitter
       {
         debugerror('close() | error closing the RTCPeerConnection: %o', error);
       }
-    }
-
-    // Close local MediaStream if it was not given by the user.
-    if (this._localMediaStream && this._localMediaStreamLocallyGenerated)
-    {
-      debug('close() | closing local MediaStream');
-
-      Utils.closeMediaStream(this._localMediaStream);
     }
 
     // Terminate signaling.


### PR DESCRIPTION
Fix for issue #683 