### PR TITLE
Support 2 bytes long UTF-8 chars in the SDP

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -41,6 +41,8 @@ module.exports = class Transport
 
     this.status = C.STATUS_DISCONNECTED;
 
+    this.textDecoder = new TextDecoder('utf8');
+
     // Current socket.
     this.socket = null;
 
@@ -343,7 +345,7 @@ module.exports = class Transport
     {
       try
       {
-        data = String.fromCharCode.apply(null, new Uint8Array(data));
+        data = this.textDecoder.decode(data);
       }
       catch (evt)
       {


### PR DESCRIPTION
At this time, 2 bytes long UTF-8 characters are displayed as junk, becuase the `new Uint8Array` is splitting away them. 