### PR TITLE
Fixing values of UA.disconnected event

### DIFF
--- a/lib/WebSocketInterface.js
+++ b/lib/WebSocketInterface.js
@@ -161,14 +161,7 @@ module.exports = class WebSocketInterface
       debug('WebSocket abrupt disconnection');
     }
 
-    const data = {
-      socket : this,
-      error  : !wasClean,
-      code,
-      reason
-    };
-
-    this.ondisconnect(data);
+    this.ondisconnect(!wasClean, code, reason);
   }
 
   _onMessage({ data })
@@ -180,6 +173,6 @@ module.exports = class WebSocketInterface
 
   _onError(e)
   {
-    debugerror(`WebSocket ${this._url} error: ${e}`);
+    debugerror(`WebSocket ${this._url} error: `, e);
   }
 };


### PR DESCRIPTION
The call of `this.ondisconnect()` function in `WebSocketInterface` calls `Transport._onDisconnect()` but this
function accept three arguments: `error`, `code` and `reason`. Not single data
object.

This causes that UA.disconnected event instead of having 4 simple
fields: `socket`, `error`, `code` and `reason` contain following object:
```
{
    socket: <socket instance>
    error: {
        socket: <socket instance>,
        error:  <valid data>,
        code:   <valid data>,
        reason: <valid data>
    },
    code: undefined,
    reason: undefined
}
```