### PR TITLE
Using other factors than only SIP URI user when trying to find a matching Contact in a Register 2xx response to prevent false matches

### DIFF
--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -10,7 +10,7 @@ module.exports = class Registrator
 {
   constructor(ua, transport)
   {
-    const reg_id=1; // Force reg_id to 1.
+    this._reg_id=1; // Force reg_id to 1.
 
     this._ua = ua;
     this._transport = transport;
@@ -47,10 +47,10 @@ module.exports = class Registrator
     // Contents of the sip.instance Contact header parameter.
     this._sipInstance = '';
 
-    if (reg_id)
+    if (this._reg_id)
     {
       this._sipInstance = `"<urn:uuid:${this._ua.configuration.instance_id}>"`;
-      this._contact += `;reg-id=${reg_id}`;
+      this._contact += `;reg-id=${this._reg_id}`;
       this._contact += `;+sip.instance=${this._sipInstance}`;
     }
   }
@@ -171,12 +171,13 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
             // Get the Contact pointing to us and update the expires value accordingly.
             let contact = undefined;
 
-            // If we have a sip.instance parameter in our Contact header then try to
-            // Find a matching Contact using that.
-            if (this._sipInstance)
+            /* If we have a reg-id and a sip.instance parameter in our Contact header then try to
+               find a matching Contact using that. */
+            if (this._reg_id && this._sipInstance)
             {
               contact = contacts.find((element) => (
-                (this._sipInstance === element.getParam('+sip.instance'))
+                (this._sipInstance === element.getParam('+sip.instance')) &&
+                (this._reg_id === parseInt(element.getParam('reg-id')))
               ));
             }
 

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -166,7 +166,9 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
 
             // Get the Contact pointing to us and update the expires value accordingly.
             const contact = contacts.find((element) => (
-              element.uri.user === this._ua.contact.uri.user
+              (element.uri.user === this._ua.contact.uri.user) &&
+              (element.uri.host === this._ua.contact.uri.host) &&
+              (element.uri.port === this._ua.contact.uri.port)
             ));
 
             if (!contact)

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -10,7 +10,8 @@ module.exports = class Registrator
 {
   constructor(ua, transport)
   {
-    this._reg_id=1; // Force reg_id to 1.
+    // Force reg_id to 1.
+    this._reg_id = 1;
 
     this._ua = ua;
     this._transport = transport;

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -44,10 +44,14 @@ module.exports = class Registrator
     // Custom Contact header params for REGISTER and un-REGISTER.
     this._extraContactParams = '';
 
+    // Contents of the sip.instance Contact header parameter
+    this._sipInstance = '';
+
     if (reg_id)
     {
+      this._sipInstance = `"<urn:uuid:${this._ua.configuration.instance_id}>"`;
       this._contact += `;reg-id=${reg_id}`;
-      this._contact += `;+sip.instance="<urn:uuid:${this._ua.configuration.instance_id}>"`;
+      this._contact += `;+sip.instance=${this._sipInstance}`;
     }
   }
 
@@ -165,11 +169,24 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
               .reduce((a, b) => a.concat(b.parsed), []);
 
             // Get the Contact pointing to us and update the expires value accordingly.
-            const contact = contacts.find((element) => (
-              (element.uri.user === this._ua.contact.uri.user) &&
-              (element.uri.host === this._ua.contact.uri.host) &&
-              (element.uri.port === this._ua.contact.uri.port)
-            ));
+            let contact = undefined;
+
+            // if we have a sip.instance parameter in our Contact header then try to
+            // find a matching Contact using that.
+            if (this._sipInstance)
+            {
+              contact = contacts.find((element) => (
+                (this._sipInstance === element.getParam('+sip.instance'))
+              ));
+            }
+
+            // if no match was found using the sip.instance try comparing the URIs
+            if (!contact)
+            {
+              contact = contacts.find((element) => (
+                (element.uri.user === this._ua.contact.uri.user)
+              ));
+            }
 
             if (!contact)
             {

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -46,14 +46,10 @@ module.exports = class Registrator
     this._extraContactParams = '';
 
     // Contents of the sip.instance Contact header parameter.
-    this._sipInstance = '';
-
-    if (this._reg_id)
-    {
-      this._sipInstance = `"<urn:uuid:${this._ua.configuration.instance_id}>"`;
-      this._contact += `;reg-id=${this._reg_id}`;
-      this._contact += `;+sip.instance=${this._sipInstance}`;
-    }
+    this._sipInstance = `"<urn:uuid:${this._ua.configuration.instance_id}>"`;
+    
+    this._contact += `;reg-id=${this._reg_id}`;
+    this._contact += `;+sip.instance=${this._sipInstance}`;
   }
 
   get registered()
@@ -169,18 +165,13 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
             const contacts = response.headers['Contact']
               .reduce((a, b) => a.concat(b.parsed), []);
 
-            // Get the Contact pointing to us and update the expires value accordingly.
-            let contact = undefined;
-
-            /* If we have a reg-id and a sip.instance parameter in our Contact header then try to
+            /* Get the Contact pointing to us and update the expires value accordingly.
+               If we have a reg-id and a sip.instance parameter in our Contact header then try to
                find a matching Contact using that. */
-            if (this._reg_id && this._sipInstance)
-            {
-              contact = contacts.find((element) => (
-                (this._sipInstance === element.getParam('+sip.instance')) &&
-                (this._reg_id === parseInt(element.getParam('reg-id')))
-              ));
-            }
+            let contact = contacts.find((element) => (
+              (this._sipInstance === element.getParam('+sip.instance')) &&
+              (this._reg_id === parseInt(element.getParam('reg-id')))
+            ));
 
             // If no match was found using the sip.instance try comparing the URIs.
             if (!contact)

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -44,7 +44,7 @@ module.exports = class Registrator
     // Custom Contact header params for REGISTER and un-REGISTER.
     this._extraContactParams = '';
 
-    // Contents of the sip.instance Contact header parameter
+    // Contents of the sip.instance Contact header parameter.
     this._sipInstance = '';
 
     if (reg_id)
@@ -171,8 +171,8 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
             // Get the Contact pointing to us and update the expires value accordingly.
             let contact = undefined;
 
-            // if we have a sip.instance parameter in our Contact header then try to
-            // find a matching Contact using that.
+            // If we have a sip.instance parameter in our Contact header then try to
+            // Find a matching Contact using that.
             if (this._sipInstance)
             {
               contact = contacts.find((element) => (
@@ -180,7 +180,7 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
               ));
             }
 
-            // if no match was found using the sip.instance try comparing the URIs
+            // If no match was found using the sip.instance try comparing the URIs.
             if (!contact)
             {
               contact = contacts.find((element) => (

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -166,8 +166,6 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
               .reduce((a, b) => a.concat(b.parsed), []);
 
             // Get the Contact pointing to us and update the expires value accordingly.
-            // If we have a reg-id and a sip.instance parameter in our Contact header then try
-            // to find a matching Contact using that.
             let contact = contacts.find((element) => (
               (this._sipInstance === element.getParam('+sip.instance')) &&
               (this._reg_id === parseInt(element.getParam('reg-id')))

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -166,6 +166,7 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
               .reduce((a, b) => a.concat(b.parsed), []);
 
             // Get the Contact pointing to us and update the expires value accordingly.
+            // Try to find a matching Contact using sip.instance and reg-id.
             let contact = contacts.find((element) => (
               (this._sipInstance === element.getParam('+sip.instance')) &&
               (this._reg_id === parseInt(element.getParam('reg-id')))

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -165,9 +165,9 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
             const contacts = response.headers['Contact']
               .reduce((a, b) => a.concat(b.parsed), []);
 
-            /* Get the Contact pointing to us and update the expires value accordingly.
-               If we have a reg-id and a sip.instance parameter in our Contact header then try to
-               find a matching Contact using that. */
+            // Get the Contact pointing to us and update the expires value accordingly.
+            // If we have a reg-id and a sip.instance parameter in our Contact header then try
+            // to find a matching Contact using that.
             let contact = contacts.find((element) => (
               (this._sipInstance === element.getParam('+sip.instance')) &&
               (this._reg_id === parseInt(element.getParam('reg-id')))


### PR DESCRIPTION
Currently Registrator.register() only uses the user part of a contact's SIP URI to find a match in the contacts received in a 2xx Register response from the server. This works fine with JsSIP's default contacts where the user part is a random token. However, this can lead to problems when the contact URI has been customized via UA config param contact_uri, which we do in our project. In our case the user part of the contact URI is set to the user part of the user's SIP credentials, so when the same user is registered on multiple devices with different clients the user part is identical for all bindings.

Consider the following example of a register:

```
common.js:108 Testapp:Softphone 2021-05-27T08:48:44.664Z (Debug): JsSIP:Transport sending message:REGISTER sip:dd146b51dfe7.us.dev.api.testhost.io SIP/2.0
Via: SIP/2.0/WSS ggvtu5dc2aam.invalid;branch=z9hG4bK3785002
Max-Forwards: 69
To: <sip:52aeb89a2913@dd146b51dfe7.us.dev.api.testhost.io>
From: "Stefan2Chrome" <sip:52aeb89a2913@dd146b51dfe7.us.dev.api.testhost.io>;tag=tebg4cft7a
Call-ID: 60b3mgqp1ec8na7aem71mu
CSeq: 2 REGISTER
Authorization: Digest algorithm=MD5, username="52aeb89a2913", realm="dd146b51dfe7.us.dev.api.testhost.io", nonce="YK9eGGCvXOy3Py8yoUlQOzdkMm8iNR/T", uri="sip:dd146b51dfe7.us.dev.api.testhost.io", response="eef582106d24b8edc96f325e81a9b85f"
Contact: <sip:52aeb89a2913@ggvtu5dc2aam.invalid;transport=ws>;+sip.ice;reg-id=1;+sip.instance="<urn:uuid:a3550190-ccef-4631-b06b-1f2382723ac1>";expires=600
Expires: 600
Allow: INVITE,ACK,CANCEL,BYE,UPDATE,MESSAGE,OPTIONS,REFER,INFO,NOTIFY
Supported: path,gruu,outbound
User-Agent: Softphone (1.6.0-beta.90/WebRTC/jsSIP 3.7.1/Chrome 90.0.4430.212/macOS 10.15.7)
Content-Length: 0

 +0ms +0ms
common.js:108 Testapp:Softphone 2021-05-27T08:48:44.664Z (Debug): JsSIP:WebSocketInterface send() +10ms +0ms
common.js:108 Testapp:Softphone 2021-05-27T08:48:44.862Z (Debug): JsSIP:WebSocketInterface received WebSocket message +198ms +198ms
common.js:108 Testapp:Softphone 2021-05-27T08:48:44.863Z (Debug): JsSIP:Transport received text message:SIP/2.0 200 OK
Via: SIP/2.0/WSS ggvtu5dc2aam.invalid;branch=z9hG4bK3785002;rport=53910;received=93.104.94.181
To: <sip:52aeb89a2913@dd146b51dfe7.us.dev.api.testhost.io>;tag=ddb25159a88af59214e4a3ffce8d28b7.150a
From: "Stefan2Chrome" <sip:52aeb89a2913@dd146b51dfe7.us.dev.api.testhost.io>;tag=tebg4cft7a
Call-ID: 60b3mgqp1ec8na7aem71mu
CSeq: 2 REGISTER
Contact: <sip:52aeb89a2913@192.168.178.59:63794;transport=tls;tinstance=64c9610a-5610-4965-8278-07fc4dc482c3>;expires=2525;received="sip:93.104.94.181:58033;transport=tls";+sip.instance="d9089d97-5fb5-4873-8248-5b667d9811ec", <sip:52aeb89a2913@ggvtu5dc2aam.invalid;transport=ws>;expires=600;received="sip:93.104.94.181:53910;transport=ws";+sip.instance="<urn:uuid:a3550190-ccef-4631-b06b-1f2382723ac1>";reg-id=1
Server:c3PR202d
Content-Length: 0
```

Here the 200 OK response contains two contacts in the Contact header, both have the same user part in the SIP URI, but different hosts. The current implementation of Registrator.register() therefore picks the first of the contacts, because it's the first one that matches the expected user part. However, it is a binding from another client with a much higher expires value, 2525 seconds instead of 600 seconds in the correct contact. This leads to an expiring registration on the server because JsSIP's registrationTimer has been configured using the incorrect 2525 value.

My change corrects that by also using the contact SIP URI's host and port parts in addition to the user parts when looking for a matching contact. This is also in line with the comparison rules defined in [section 19.1.4 of RFC 3261](https://datatracker.ietf.org/doc/html/rfc3261#section-19.1.4).