### PR TITLE
Fix invalid state error on DTMF send

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -961,7 +961,11 @@ module.exports = class RTCSession extends EventEmitter
     }
 
     // Check Session Status.
-    if (this._status !== C.STATUS_CONFIRMED && this._status !== C.STATUS_WAITING_FOR_ACK)
+    if (
+      this._status !== C.STATUS_CONFIRMED &&
+      this._status !== C.STATUS_WAITING_FOR_ACK &&
+      this._status !== C.STATUS_1XX_RECEIVED
+      )
     {
       throw new Exceptions.InvalidStateError(this._status);
     }
@@ -1104,7 +1108,11 @@ module.exports = class RTCSession extends EventEmitter
     logger.debug('sendInfo()');
 
     // Check Session Status.
-    if (this._status !== C.STATUS_CONFIRMED && this._status !== C.STATUS_WAITING_FOR_ACK)
+    if (
+      this._status !== C.STATUS_CONFIRMED &&
+      this._status !== C.STATUS_WAITING_FOR_ACK &&
+      this._status !== C.STATUS_1XX_RECEIVED
+      )
     {
       throw new Exceptions.InvalidStateError(this._status);
     }


### PR DESCRIPTION
Sending a DTMF tone after a `183 Session Progress` for example would raise an `INVALID_STATE_ERROR`. This PR fixes that.