### PR TITLE
Fix for Firefox ICE gathering work around issue.

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -93,6 +93,9 @@ module.exports = class RTCSession extends EventEmitter
     // Flag to indicate PeerConnection ready for new actions.
     this._rtcReady = true;
 
+    // Flag to indicate ICE candidate gathering is finished even if iceGatheringState is not yet 'complete'.
+    this._iceReady = false;
+
     // SIP Timers.
     this._timers = {
       ackTimer          : null,
@@ -1924,7 +1927,10 @@ module.exports = class RTCSession extends EventEmitter
       .then(() =>
       {
         // Resolve right away if 'pc.iceGatheringState' is 'complete'.
-        if (connection.iceGatheringState === 'complete' && (!constraints || !constraints.iceRestart))
+        // Also resolve if the state is still 'gathering' but has already been interrupted via ready().
+        if ((connection.iceGatheringState === 'complete' ||
+          (this._iceReady && connection.iceGatheringState === 'gathering')) &&
+          (!constraints || !constraints.iceRestart))
         {
           this._rtcReady = true;
 
@@ -1944,6 +1950,8 @@ module.exports = class RTCSession extends EventEmitter
           let iceCandidateListener;
           let iceGatheringStateListener;
 
+          this._iceReady = false;
+
           const ready = () =>
           {
             connection.removeEventListener('icecandidate', iceCandidateListener);
@@ -1951,6 +1959,9 @@ module.exports = class RTCSession extends EventEmitter
 
             finished = true;
             this._rtcReady = true;
+
+            // connection.iceGatheringState will still indicate 'gathering' and thus be blocking.
+            this._iceReady = true;
 
             const e = { originator: 'local', type: type, sdp: connection.localDescription.sdp };
 

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1927,10 +1927,15 @@ module.exports = class RTCSession extends EventEmitter
       .then(() =>
       {
         // Resolve right away if 'pc.iceGatheringState' is 'complete'.
-        // Also resolve if the state is still 'gathering' but has already been interrupted via ready().
-        if ((connection.iceGatheringState === 'complete' ||
-          (this._iceReady && connection.iceGatheringState === 'gathering')) &&
-          (!constraints || !constraints.iceRestart))
+        /**
+         * Resolve right away if:
+         * - 'connection.iceGatheringState' is 'complete' and no 'iceRestart' constraint is set.
+         * - 'connection.iceGatheringState' is 'gathering' and 'iceReady' is true.
+         */
+        const iceRestart = constraints && constraints.iceRestart;
+        
+        if ((connection.iceGatheringState === 'complete' && !iceRestart) ||
+          (connection.iceGatheringState === 'gathering' && this._iceReady))
         {
           this._rtcReady = true;
 


### PR DESCRIPTION
I have a event listener for icecandidate events. This event listener starts a timeout of 1 second when ICE candidate gathering starts and when it expires it executes the event.ready() function that aborts ICE candidate gathering in case it hasn't yet finished.
This is a work around for a known WebRTC issue that occurs in Firefox where Firefox takes 10 seconds to finish gathering ICE candidates.
So far this works as desired and if for example a incoming SIP call gets answered it only takes a bit over 1 second until the call is answered, which is acceptable.

The issue I ran into is that if within the first 10 (or in my case 9) seconds a SDP re-negotiation occurs (e.g. triggered by a re-INVITE) the request / response will not be sent until the original ICE gathering finished.
This delay is especially unwanted since we already marked ICE gathering as ready via our own timeout and we won't receive new icecandidate events that would allow us to set a new timer.

This pull request adds a persistent flag that allows by-passing gathering new ICE candidates if the ongoing gathering process was previously interrupted.
From what I understood from the code the behavior slightly differs from _rtcReady which is why I introduced a flag called _iceReady instead of modifying the code the use _rtcReady for that purpose. I could be wrong.