### PR TITLE
Fix WebSocketInterface ondisconnect typings

### DIFF
--- a/lib/WebSocketInterface.d.ts
+++ b/lib/WebSocketInterface.d.ts
@@ -1,10 +1,3 @@
-export interface DisconnectEvent {
-  socket: Socket;
-  error: boolean;
-  code?: number;
-  reason?: string;
-}
-
 export interface WeightedSocket  {
   socket: Socket;
   weight: number
@@ -30,7 +23,7 @@ export class Socket {
 
   onconnect(): void;
 
-  ondisconnect(event: DisconnectEvent): void;
+  ondisconnect(withError: boolean, code?: number, reason?: string): void;
 
   ondata<T>(event: T): void;
 }


### PR DESCRIPTION
Hi!

I wanted to write my own WebSocketInterface and use reconnection mechanism from JsSIP. However to use it I need to call ondisconnect from my code to trigger transport reconnect on JsSIP. However I'm not able to do it since typings for ondisconnect are wrong.

Relevant lines of code:
Here socket's `ondisconnect` gets bind to Transport's `_onDisconnect` - [https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L146](https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L146)
Transport's `_onDisconnect` is declared with 3 arguments and not a one argument object - [https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L311](https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L311)

I believe that these typings were probably mismatched for the Transport's `ondisconnect`, which has exactly that interface -[https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L314](https://github.com/versatica/JsSIP/blob/master/lib/Transport.js#L314)