### PR TITLE
Enable custom From-Header for SIP Message

### DIFF
--- a/lib/Message.d.ts
+++ b/lib/Message.d.ts
@@ -26,6 +26,8 @@ export interface MessageEventMap {
 export interface SendMessageOptions extends ExtraHeaders {
   contentType?: string;
   eventHandlers?: Partial<MessageEventMap>;
+  fromUserName?: string;
+  fromDisplayName?: string;
 }
 
 export class Message extends EventEmitter {

--- a/lib/Message.js
+++ b/lib/Message.js
@@ -5,6 +5,7 @@ const SIPMessage = require('./SIPMessage');
 const Utils = require('./Utils');
 const RequestSender = require('./RequestSender');
 const Exceptions = require('./Exceptions');
+const URI = require('./URI');
 
 const logger = new Logger('Message');
 
@@ -65,6 +66,20 @@ module.exports = class Message extends EventEmitter
     const eventHandlers = Utils.cloneObject(options.eventHandlers);
     const contentType = options.contentType || 'text/plain';
 
+    const requestParams = {};
+
+    if (options.fromUserName)
+    {
+      requestParams.from_uri = new URI('sip', options.fromUserName, this._ua.configuration.uri.host);
+
+      extraHeaders.push(`P-Preferred-Identity: ${this._ua.configuration.uri.toString()}`);
+    }
+
+    if (options.fromDisplayName)
+    {
+      requestParams.from_display_name = options.fromDisplayName;
+    }
+
     // Set event handlers.
     for (const event in eventHandlers)
     {
@@ -77,7 +92,7 @@ module.exports = class Message extends EventEmitter
     extraHeaders.push(`Content-Type: ${contentType}`);
 
     this._request = new SIPMessage.OutgoingRequest(
-      JsSIP_C.MESSAGE, target, this._ua, null, extraHeaders);
+      JsSIP_C.MESSAGE, target, this._ua, requestParams, extraHeaders);
 
     if (body)
     {


### PR DESCRIPTION
Enables customization of From-Header for SIP Messages as suggested in #752. Implementation according to #677.

Best regards,
gebsl