### PR TITLE
Improve matching of empty message received

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -345,6 +345,8 @@ module.exports = class Transport
     {
       logger.debug('received message with CRLF Keep Alive response');
 
+      this.socket.send('Assume that is a keep alive... So Pong');
+
       return;
     }
 

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -341,7 +341,7 @@ module.exports = class Transport
   _onData(data)
   {
     // CRLF Keep Alive response from server. Ignore it.
-    if (data === '\r\n')
+    if (data.match(/^\r\n/))
     {
       logger.debug('received message with CRLF Keep Alive response');
 


### PR DESCRIPTION
Hi,

With PjSIP, empty messages received was not only "\r\n" (see below). So I change the strict matching by a regular.

Other question, why not response to this ?

Regards,
Boris.

![image](https://user-images.githubusercontent.com/661705/142233400-fc45c600-fa8c-4ca7-8573-659f39740b8d.png)
