### PR TITLE
Fixed REFER NOTIFY parsing in accordance to RFC 3515 section 2.4.5

### DIFF
--- a/lib/RTCSession/ReferSubscriber.js
+++ b/lib/RTCSession/ReferSubscriber.js
@@ -102,7 +102,7 @@ module.exports = class ReferSubscriber extends EventEmitter
       return;
     }
 
-    const status_line = Grammar.parse(request.body.trim(), 'Status_Line');
+    const status_line = Grammar.parse(request.body.trim().split('\r\n', 1)[0], 'Status_Line');
 
     if (status_line === -1)
     {

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -411,5 +411,16 @@ module.exports = {
     test.strictEqual(parsed.from_tag, 'kun98clbf7');
 
     test.done();
+  },
+
+  'parse Status Line' : function(test)
+  {
+    const data = 'SIP/2.0 420 Bad Extension';
+    let parsed;
+
+    test.ok((parsed = JsSIP.Grammar.parse(data, 'Status_Line')) !== -1);
+    test.strictEqual(parsed.status_code, 420);
+
+    test.done();
   }
 };


### PR DESCRIPTION
I observed failures to parse the body of a refer NOTIFY in JsSIP if the body contained more than just a status line. 
According to RFC 3515 section 2.4.5 it is allowed for additional SIP headers to be in the NOTIFY body in addition to the status line.  In accordance with that I changed the JsSIP code so the Status_Line parser is only used to parse the first line of the NOTIFY body, which according to the RFC always contains the status line. Thus the parser will no longer throw an error if there is additional data in the body after the status line.

For reference, this is the NOTIFY body that was received:
> SIP/2.0 420 Bad Extension
> Reason: SIP;cause=183;text="Call in progress"