### PR TITLE
Fix for RTCSession 'confirmed' event handler type description

### DIFF
--- a/lib/RTCSession.d.ts
+++ b/lib/RTCSession.d.ts
@@ -165,7 +165,16 @@ export interface IceCandidateEvent {
 
 export interface OutgoingEvent {
   originator: Originator.REMOTE;
-  response: IncomingResponse
+  response: IncomingResponse;
+}
+
+export interface OutgoingAckEvent {
+  originator: Originator.LOCAL;
+}
+
+export interface IncomingAckEvent {
+  originator: Originator.REMOTE;
+  ack: IncomingRequest;
 }
 
 // listener
@@ -175,7 +184,10 @@ export type ConnectingListener = (event: ConnectingEvent) => void;
 export type SendingListener = (event: SendingEvent) => void;
 export type IncomingListener = (event: IncomingEvent) => void;
 export type OutgoingListener = (event: OutgoingEvent) => void;
+export type IncomingConfirmedListener = (event: IncomingAckEvent) => void;
+export type OutgoingConfirmedListener = (event: OutgoingAckEvent) => void;
 export type CallListener = IncomingListener | OutgoingListener;
+export type ConfirmedListener = IncomingConfirmedListener | OutgoingConfirmedListener;
 export type EndListener = (event: EndEvent) => void;
 export type IncomingDTMFListener = (event: IncomingDTMFEvent) => void;
 export type OutgoingDTMFListener = (event: OutgoingDTMFEvent) => void;
@@ -197,7 +209,7 @@ export interface RTCSessionEventMap {
   'sending': SendingListener;
   'progress': CallListener;
   'accepted': CallListener;
-  'confirmed': CallListener;
+  'confirmed': ConfirmedListener;
   'ended': EndListener;
   'failed': EndListener;
   'newDTMF': DTMFListener;


### PR DESCRIPTION
The TypeScript type description for the event handler for RTCSession 'confirmed' events specifies that for incoming ACK the handler is invoked with an object of type OutgoingEvent, i.e. `{
  originator: Originator.REMOTE;
  response: IncomingResponse;
}`. However, this doesn't seem to be correct. When looking at `RTCSession._confirmed` it is clear that the 'confirmed' event is actually accompanied by an object of type `{
  originator: Originator.REMOTE;
  ack: IncomingRequest;
}`. It seems this has always been the case, so apparently the type description that was added later is incorrect here. I have provided a patch that remedies this.

The API documentation https://jssip.net/documentation/3.9.x/api/session/#event_confirmed is incorrect, too. It also mentions a member 'response' of type IncomingResponse and even states that this is a 200 OK response, while the member is actually called 'ack', is of type IncomingRequest and is an ACK, not an OK. The documentation is not in this repo, though, so that needs to be corrected separately.