### PR TITLE
New UA config param for global extra headers

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -41,6 +41,9 @@ exports.settings = {
   connection_recovery_max_interval : JsSIP_C.CONNECTION_RECOVERY_MAX_INTERVAL,
   connection_recovery_min_interval : JsSIP_C.CONNECTION_RECOVERY_MIN_INTERVAL,
 
+  // Global extra headers, to be added to every request and response
+  extra_headers : null,
+
   /*
    * Host address.
    * Value to be set in Via sent_by and host part of Contact FQDN.
@@ -308,6 +311,28 @@ const checks = {
       {
         return use_preloaded_route;
       }
+    },
+
+    extra_headers(extra_headers)
+    {
+      const _extraHeaders = [];
+
+      if (Array.isArray(extra_headers) && extra_headers.length)
+      {
+        for (const header of extra_headers)
+        {
+          if (typeof header === 'string')
+          {
+            _extraHeaders.push(header);
+          }
+        }
+      }
+      else
+      {
+        return;
+      }
+
+      return _extraHeaders;
     }
   }
 };

--- a/lib/SIPMessage.js
+++ b/lib/SIPMessage.js
@@ -35,6 +35,10 @@ class OutgoingRequest
     this.ruri = ruri;
     this.body = body;
     this.extraHeaders = Utils.cloneArray(extraHeaders);
+    if (this.ua.configuration.extra_headers)
+    {
+      this.extraHeaders = this.extraHeaders.concat(this.ua.configuration.extra_headers);
+    }
 
     // Fill the Common SIP Request Headers.
 
@@ -596,6 +600,10 @@ class IncomingRequest extends IncomingMessage
 
     reason = reason || JsSIP_C.REASON_PHRASE[code] || '';
     extraHeaders = Utils.cloneArray(extraHeaders);
+    if (this.ua.configuration.extra_headers)
+    {
+      extraHeaders = extraHeaders.concat(this.ua.configuration.extra_headers);
+    }
 
     let response = `SIP/2.0 ${code} ${reason}\r\n`;
 
@@ -739,6 +747,15 @@ class IncomingRequest extends IncomingMessage
     response += `From: ${this.getHeader('From')}\r\n`;
     response += `Call-ID: ${this.call_id}\r\n`;
     response += `CSeq: ${this.cseq} ${this.method}\r\n`;
+
+    if (this.ua.configuration.extra_headers)
+    {
+      for (const header of this.ua.configuration.extra_headers)
+      {
+        response += `${header.trim()}\r\n`;
+      }
+    }
+
     response += `Content-Length: ${0}\r\n\r\n`;
 
     this.transport.send(response);

--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -44,6 +44,7 @@ export interface UAConfiguration {
   registrar_server?: string;
   use_preloaded_route?: boolean;
   user_agent?: string;
+  extra_headers?: string[];
 }
 
 export interface IncomingRTCSessionEvent {


### PR DESCRIPTION
Some proprietary SIP call managers require the presence of specific extra SIP headers to be present in every single request and response from a client. Currently JsSIP doesn't have a way to accomplish that, extra headers can only be added to some specific requests and responses that are directly triggered via JsSIP APIs like UA.call() or RTCSession.answer(), but many requests/responses that are triggered internally by JsSIP like ACKs or error responses don't contain these headers.

This PR adds the new UA configuration entry "extra_headers", which contains headers that should be added to every request and response, even provisional responses and ACKs. Any extra headers that are provided through the already existing APIs are added on top of these global extra headers.