### PR TITLE
MD5: Do not strip new line

### DIFF
--- a/lib/Utils.js
+++ b/lib/Utils.js
@@ -377,7 +377,6 @@ exports.calculateMD5 = (string) =>
 
   function utf8Encode(str)
   {
-    str = str.replace(/\r\n/g, '\n');
     let utftext = '';
 
     for (let n = 0; n < str.length; n++)


### PR DESCRIPTION
Closes #609.

Verified with MacOS MD5 command. New line is not removed from the string.

<img width="288" alt="Screenshot 2022-11-05 at 17 33 53" src="https://user-images.githubusercontent.com/732340/200131399-d7dbf73f-4be2-4018-8d67-504ee504c4ac.png">
<img width="348" alt="Screenshot 2022-11-05 at 17 33 45" src="https://user-images.githubusercontent.com/732340/200131400-f62f1a19-5d7c-4daf-85af-6924e4f4a585.png">
