### PR TITLE
TS: fix socket/transport types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+### NEXT RELEASE
+
+* TS: fix socket/transport types (#790).
+
+
 ### 3.10.0
 
 * Fix typescript typings (#648).

--- a/lib/Socket.d.ts
+++ b/lib/Socket.d.ts
@@ -1,0 +1,29 @@
+export interface WeightedSocket  {
+  socket: Socket;
+  weight: number
+}
+
+export class Socket {
+  get via_transport(): string;
+  set via_transport(value: string);
+
+  get url(): string;
+
+  get sip_uri(): string;
+
+  connect(): void;
+
+  disconnect(): void;
+
+  send(message: string | ArrayBufferLike | Blob | ArrayBufferView): boolean;
+
+  isConnected(): boolean;
+
+  isConnecting(): boolean;
+
+  onconnect(): void;
+
+  ondisconnect(error: boolean, code?: number, reason?: string): void;
+
+  ondata<T>(event: T): void;
+}

--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -1,4 +1,4 @@
-import {Socket} from './WebSocketInterface'
+import {Socket} from './Socket'
 
 export interface RecoveryOptions {
   min_interval: number;

--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -1,6 +1,6 @@
 import {EventEmitter, Listener} from 'events'
 
-import {DisconnectEvent, Socket, WeightedSocket} from './WebSocketInterface'
+import {Socket, WeightedSocket} from './Socket'
 import {AnswerOptions, Originator, RTCSession, RTCSessionEventMap, TerminateOptions} from './RTCSession'
 import {IncomingRequest, IncomingResponse, OutgoingRequest} from './SIPMessage'
 import {Message, SendMessageOptions} from './Message'
@@ -60,13 +60,20 @@ export interface OutgoingRTCSessionEvent {
 
 export type RTCSessionEvent = IncomingRTCSessionEvent | OutgoingRTCSessionEvent;
 
-export interface UAConnectingEvent {
+export interface ConnectingEvent {
   socket: Socket;
   attempts: number
 }
 
 export interface ConnectedEvent {
   socket: Socket;
+}
+
+export interface DisconnectEvent {
+  socket: Socket;
+  error: boolean;
+  code?: number;
+  reason?: string;
 }
 
 export interface RegisteredEvent {
@@ -100,7 +107,7 @@ export interface OutgoingOptionsEvent {
   request: OutgoingRequest;
 }
 
-export type UAConnectingListener = (event: UAConnectingEvent) => void;
+export type ConnectingListener = (event: ConnectingEvent) => void;
 export type ConnectedListener = (event: ConnectedEvent) => void;
 export type DisconnectedListener = (event: DisconnectEvent) => void;
 export type RegisteredListener = (event: RegisteredEvent) => void;
@@ -118,7 +125,7 @@ export type OptionsListener = IncomingOptionsListener | OutgoingOptionsListener;
 export type SipEventListener = <T = any>(event: { event: T; request: IncomingRequest; }) => void
 
 export interface UAEventMap {
-  connecting: UAConnectingListener;
+  connecting: ConnectingListener;
   connected: ConnectedListener;
   disconnected: DisconnectedListener;
   registered: RegisteredListener;

--- a/lib/WebSocketInterface.d.ts
+++ b/lib/WebSocketInterface.d.ts
@@ -1,39 +1,4 @@
-export interface DisconnectEvent {
-  socket: Socket;
-  error: boolean;
-  code?: number;
-  reason?: string;
-}
-
-export interface WeightedSocket  {
-  socket: Socket;
-  weight: number
-}
-
-export class Socket {
-  get via_transport(): string;
-  set via_transport(value: string);
-
-  get url(): string;
-
-  get sip_uri(): string;
-
-  connect(): void;
-
-  disconnect(): void;
-
-  send(message: string | ArrayBufferLike | Blob | ArrayBufferView): boolean;
-
-  isConnected(): boolean;
-
-  isConnecting(): boolean;
-
-  onconnect(): void;
-
-  ondisconnect(event: DisconnectEvent): void;
-
-  ondata<T>(event: T): void;
-}
+import { Socket } from './Socket';
 
 export class WebSocketInterface extends Socket {
   constructor(url: string)


### PR DESCRIPTION
Fixes #743.

* Create Socket type definitions.
* Fix ondisconnect definition for Socket (previously defined in WebsocketInterface).
* Create missing definitions for UA connection events.