### PR TITLE
Allow to send REGISTER request without `expires`

### DIFF
--- a/lib/Config.js
+++ b/lib/Config.js
@@ -275,7 +275,7 @@ const checks = {
       {
         const value = Number(register_expires);
 
-        if (value > 0)
+        if (value >= 0)
         {
           return value;
         }

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -104,9 +104,10 @@ module.exports = class Registrator
     }
 
     const extraHeaders = this._extraHeaders.slice();
+    let contactValue = `${this._contact}${this._extraContactParams}`;
 
-    extraHeaders.push(`Contact: \
-${this._contact};expires=${this._expires}${this._extraContactParams}`);
+    if (this._expires) contactValue = `${this._contact};expires=${this._expires}${this._extraContactParams}`;
+    extraHeaders.push(`Contact: ${contactValue}`);
     if (this._expires) extraHeaders.push(`Expires: ${this._expires}`);
 
     const request = new SIPMessage.OutgoingRequest(

--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -49,7 +49,7 @@ module.exports = class Registrator
 
     // Contents of the sip.instance Contact header parameter.
     this._sipInstance = `"<urn:uuid:${this._ua.configuration.instance_id}>"`;
-    
+
     this._contact += `;reg-id=${this._reg_id}`;
     this._contact += `;+sip.instance=${this._sipInstance}`;
   }
@@ -107,7 +107,7 @@ module.exports = class Registrator
 
     extraHeaders.push(`Contact: \
 ${this._contact};expires=${this._expires}${this._extraContactParams}`);
-    extraHeaders.push(`Expires: ${this._expires}`);
+    if (this._expires) extraHeaders.push(`Expires: ${this._expires}`);
 
     const request = new SIPMessage.OutgoingRequest(
       JsSIP_C.REGISTER, this._registrar, this._ua, {


### PR DESCRIPTION
This PR adding ability to send REGISTERs without `expires` value and let the server side decide what the `expires` is.

This is done by setting `register_expires` to zero in UA config.