### PR TITLE
Sync_audioMuted and _videoMuted with local mediaStream is provided

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -657,6 +657,7 @@ module.exports = class RTCSession extends EventEmitter
         // A local MediaStream is given, use it.
         if (mediaStream)
         {
+          this._checkLocalMediaStream(mediaStream);
           return mediaStream;
         }
 
@@ -2621,6 +2622,7 @@ module.exports = class RTCSession extends EventEmitter
         // A stream is given, let the app set events such as 'peerconnection' and 'connecting'.
         if (mediaStream)
         {
+          this._checkLocalMediaStream(mediaStream);
           return mediaStream;
         }
         // Request for user media access.
@@ -3442,6 +3444,26 @@ module.exports = class RTCSession extends EventEmitter
         });
       }, expires * 1100);
     }
+  }
+
+  /**
+   * Syncs muted status of audio to mediaStream option passed to answer and connect functions.
+   */
+  _checkLocalMediaStream(mediaStream) {
+
+    if (!mediaStream || typeof mediaStream.getTracks !== "function")
+      return;
+
+    mediaStream.getTracks().forEach((track) => {
+
+      if (track.kind === "audio") {
+        this._audioMuted = track.enabled ? false : true;
+      }
+      else {
+        this._videoMuted = track.enabled ? false : true;
+      }
+
+    });
   }
 
   _toggleMuteAudio(mute)


### PR DESCRIPTION
This commit resolves an issue whereby when a local mediaStream is passed as an option to the answer or connect functions, the existing code does not sync the enabled status.