### PR TITLE
Fix re-export Socket types from WebSocketInterface

### DIFF
--- a/lib/WebSocketInterface.d.ts
+++ b/lib/WebSocketInterface.d.ts
@@ -1,5 +1,5 @@
 import { Socket } from './Socket';
-
+export { WeightedSocket, Socket} from './Socket'
 export class WebSocketInterface extends Socket {
   constructor(url: string)
 }


### PR DESCRIPTION
When the commit id is 004d160, move the Socket and WeightedSocket of Websocket Interface.d.ts to Socket.d.ts, but JsSIP.d.ts is still importing Socket and WeightedSocket from WebsocketInterface.d.ts
