### PR TITLE
feat: fire sipEvent on RTCSession when STATUS_WAITING_FOR_ANSWER

### DIFF
--- a/lib/RTCSession.d.ts
+++ b/lib/RTCSession.d.ts
@@ -176,6 +176,11 @@ export interface IncomingAckEvent {
   ack: IncomingRequest;
 }
 
+export interface SipEvent {
+  event: string;
+  request: IncomingRequest;
+}
+
 // listener
 export type PeerConnectionListener = (event: PeerConnectionEvent) => void;
 export type ConnectingListener = (event: ConnectingEvent) => void;
@@ -200,6 +205,7 @@ export type UpdateListener = ReInviteListener;
 export type ReferListener = (event: ReferEvent) => void;
 export type SDPListener = (event: SDPEvent) => void;
 export type IceCandidateListener = (event: IceCandidateEvent) => void;
+export type SipEventListener = (event: SipEvent) => void;
 
 export interface RTCSessionEventMap {
   'peerconnection': PeerConnectionListener;
@@ -227,6 +233,7 @@ export interface RTCSessionEventMap {
   'peerconnection:createanswerfailed': Listener;
   'peerconnection:setlocaldescriptionfailed': Listener;
   'peerconnection:setremotedescriptionfailed': Listener;
+  'sipEvent': SipEventListener
 }
 
 declare enum SessionStatus {

--- a/lib/RTCSession.d.ts
+++ b/lib/RTCSession.d.ts
@@ -233,7 +233,7 @@ export interface RTCSessionEventMap {
   'peerconnection:createanswerfailed': Listener;
   'peerconnection:setlocaldescriptionfailed': Listener;
   'peerconnection:setremotedescriptionfailed': Listener;
-  'sipEvent': SipEventListener
+  'sipEvent': SipEventListener;
 }
 
 declare enum SessionStatus {

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1598,7 +1598,7 @@ module.exports = class RTCSession extends EventEmitter
           }
           break;
         case JsSIP_C.NOTIFY:
-          if (this._status === C.STATUS_CONFIRMED)
+          if (this._status === C.STATUS_CONFIRMED || this._status === C.STATUS_WAITING_FOR_ANSWER)
           {
             this._receiveNotify(request);
           }
@@ -2538,6 +2538,14 @@ module.exports = class RTCSession extends EventEmitter
         referSubscriber.receiveNotify(request);
         request.reply(200);
 
+        break;
+      }
+      case 'talk': {
+        request.reply(200);
+        this.emit('sipEvent', {
+          event: request.event,
+          request: request
+        });
         break;
       }
 


### PR DESCRIPTION
when jssip receivce NOTIFY (in dialog) before call answer,  jssip reply with 403 Wrong Status.

but we want to use in-dialog NOTIFY

the code below is my in app , no in jssip

```js
myPhone.on('newRTCSession', ({ session, originator, request })=>{

    session.on('sipEvent', (e) => {
       
    })
})
```