### PR TITLE
Fix type definitions to not import `Listener` from `events` (fixes: #799)

### DIFF
--- a/lib/RTCSession.d.ts
+++ b/lib/RTCSession.d.ts
@@ -1,4 +1,4 @@
-import {EventEmitter, Listener} from 'events'
+import {EventEmitter} from 'events'
 
 import {IncomingRequest, IncomingResponse, OutgoingRequest} from './SIPMessage'
 import {NameAddrHeader} from './NameAddrHeader'
@@ -177,6 +177,7 @@ export interface IncomingAckEvent {
 }
 
 // listener
+export type GenericErrorListener = (error: any) => void;
 export type PeerConnectionListener = (event: PeerConnectionEvent) => void;
 export type ConnectingListener = (event: ConnectingEvent) => void;
 export type SendingListener = (event: SendingEvent) => void;
@@ -222,11 +223,11 @@ export interface RTCSessionEventMap {
   'replaces': ReferListener;
   'sdp': SDPListener;
   'icecandidate': IceCandidateListener;
-  'getusermediafailed': Listener;
-  'peerconnection:createofferfailed': Listener;
-  'peerconnection:createanswerfailed': Listener;
-  'peerconnection:setlocaldescriptionfailed': Listener;
-  'peerconnection:setremotedescriptionfailed': Listener;
+  'getusermediafailed': GenericErrorListener;
+  'peerconnection:createofferfailed': GenericErrorListener;
+  'peerconnection:createanswerfailed': GenericErrorListener;
+  'peerconnection:setlocaldescriptionfailed': GenericErrorListener;
+  'peerconnection:setremotedescriptionfailed': GenericErrorListener;
 }
 
 declare enum SessionStatus {

--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -1,4 +1,4 @@
-import {EventEmitter, Listener} from 'events'
+import {EventEmitter} from 'events'
 
 import {Socket, WeightedSocket} from './Socket'
 import {AnswerOptions, Originator, RTCSession, RTCSessionEventMap, TerminateOptions} from './RTCSession'
@@ -113,6 +113,7 @@ export type DisconnectedListener = (event: DisconnectEvent) => void;
 export type RegisteredListener = (event: RegisteredEvent) => void;
 export type UnRegisteredListener = (event: UnRegisteredEvent) => void;
 export type RegistrationFailedListener = UnRegisteredListener;
+export type RegistrationExpiringListener = () => void;
 export type IncomingRTCSessionListener = (event: IncomingRTCSessionEvent) => void;
 export type OutgoingRTCSessionListener = (event: OutgoingRTCSessionEvent) => void;
 export type RTCSessionListener = IncomingRTCSessionListener | OutgoingRTCSessionListener;
@@ -131,7 +132,7 @@ export interface UAEventMap {
   registered: RegisteredListener;
   unregistered: UnRegisteredListener;
   registrationFailed: RegistrationFailedListener;
-  registrationExpiring: Listener;
+  registrationExpiring: RegistrationExpiringListener;
   newRTCSession: RTCSessionListener;
   newMessage: MessageListener;
   sipEvent: SipEventListener;


### PR DESCRIPTION
The type definitions provided by `@types/events` clash with those by `@types/node`, resulting in the error:

         Module '"events"' has no exported member 'Listener'.

In practice this makes it impossible to use JsSIP in any Angular project, resulting in issues such as #799.

Looking at the places where `Listener` is being imported, we are not gaining anything by using this type definition which is extremely generic. We can do better by using a more specific type definition.