### PR TITLE
Fixed some broken TypeScript definitions in RTCSession.d.ts and UA.d.ts

### DIFF
--- a/lib/RTCSession.d.ts
+++ b/lib/RTCSession.d.ts
@@ -171,6 +171,11 @@ export interface IncomingAckEvent {
   ack: IncomingRequest;
 }
 
+export interface MediaStreamTypes {
+  audio?: boolean;
+  video?: boolean;
+}
+
 // listener
 export type GenericErrorListener = (error: any) => void;
 export type PeerConnectionListener = (event: PeerConnectionEvent) => void;
@@ -190,7 +195,7 @@ export type IncomingInfoListener = (event: IncomingInfoEvent) => void;
 export type OutgoingInfoListener = (event: OutgoingInfoEvent) => void;
 export type InfoListener = IncomingInfoListener | OutgoingInfoListener;
 export type HoldListener = (event: HoldEvent) => void;
-export type MuteListener = (event: MediaConstraints) => void;
+export type MuteListener = (event: MediaStreamTypes) => void;
 export type ReInviteListener = (event: ReInviteEvent) => void;
 export type UpdateListener = ReInviteListener;
 export type ReferListener = (event: ReferEvent) => void;
@@ -290,11 +295,11 @@ export class RTCSession extends EventEmitter {
 
   isOnHold(): OnHoldResult;
 
-  mute(options?: MediaConstraints): void;
+  mute(options?: MediaStreamTypes): void;
 
-  unmute(options?: MediaConstraints): void;
+  unmute(options?: MediaStreamTypes): void;
 
-  isMuted(): MediaConstraints;
+  isMuted(): MediaStreamTypes;
 
   refer(target: string | URI, options?: ReferOptions): void;
 

--- a/lib/UA.d.ts
+++ b/lib/UA.d.ts
@@ -40,7 +40,7 @@ export interface UAConfiguration {
   ha1?: string;
   register?: boolean;
   register_expires?: number;
-  register_from_tag_trail?: string | function() : string;
+  register_from_tag_trail?: string | (() => string);
   registrar_server?: string;
   use_preloaded_route?: boolean;
   user_agent?: string;
@@ -56,7 +56,7 @@ export interface IncomingRTCSessionEvent {
 export interface OutgoingRTCSessionEvent {
   originator: Originator.LOCAL;
   session: RTCSession;
-  request: IncomingRequest;
+  request: OutgoingRequest;
 }
 
 export type RTCSessionEvent = IncomingRTCSessionEvent | OutgoingRTCSessionEvent;


### PR DESCRIPTION
This commit fixes some type definitions that unfortunately were broken by some of the recent merges of some pull request.

Commit d547d74be9f757dc23a1065670c8d10515152f17 (Use built-in MediaStreamConstraints type (#809)) removed the interface MediaConstraints, but failed to adjust the definitions of RTCSession's MuteListener and the mute, unmute and isMuted functions.
This leads to errors when transpiling with TypeScript:
TS2552: Cannot find name MediaConstraints. Did you mean MediaTrackConstraints?

Commit 901574f75e06645776a4fad5793903d3c8488844 (Allow to configure from-tag in register (#793)) introduced UAConfiguration.register_from_tag_trail with an invalid type that causes an error with TypeScript:
TS8020: JSDoc types can only be used inside documentation comments.

I also took the opportunity to fix a wrong type definition in OutgoingRTCSessionEvent, for which there is also an open issue #821.