### PR TITLE
fix register re-try on 423 response

### DIFF
--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -273,6 +273,7 @@ ${this._contact};expires=${this._expires}${this._extraContactParams}`);
               if (this._expires < MIN_REGISTER_EXPIRES)
                 this._expires = MIN_REGISTER_EXPIRES;
 
+              this._registering = false; // assure register re-try with new expire
               // Attempt the registration again immediately.
               this.register();
             }


### PR DESCRIPTION
fails to re-try register with new expire header and value on 423
because param ```this._registering``` is still true

https://github.com/versatica/JsSIP/blob/f3ebc9eca82ff90f2cbd9279562711cf9fe3a940/lib/Registrator.js#L99-L104