### PR TITLE
Correction in sending DTMF via SIP INFO

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -1055,14 +1055,7 @@ module.exports = class RTCSession extends EventEmitter
       return;
     }
 
-    if (this._tones)
-    {
-      // Tones are already queued, just add to the queue.
-      this._tones += tones;
-
-      return;
-    }
-
+    position = 0;
     this._tones = tones;
 
     // Send the first tone.


### PR DESCRIPTION
### Problem:
When using the `sendDTMF` function, sending multiple DTMFs failed because the position was not being correctly reset after sending each tone, which resulted in tones being ignored or not sent properly.

### Previous behavior:
In the previous state, the logic was not adequate to correctly handle the sending of multiple tones, causing interruptions in the sequential sending of DTMFs. The specific problem was that the code used incorrect logic for manipulating the `position` index, which caused errors when DTMFs were queued.

### Solution:
The implemented correction restructures the management of the `position` variable and ensures that DTMFs are sent correctly, one at a time, respecting the configured duration and interToneGap values.

Additionally, new logic resets `position` to ensure that all tones in the queue are sent correctly, resolving the issue of tones being omitted or ignored during the send sequence.

### Tests:
After the correction, DTMF sending was validated and all tones were sent as expected without interruptions.