### PR TITLE
Add support for sender encodings priority option

### DIFF
--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -278,6 +278,7 @@ module.exports = class RTCSession extends EventEmitter
     const pcConfig = Utils.cloneObject(options.pcConfig, { iceServers: [] });
     const rtcConstraints = options.rtcConstraints || null;
     const rtcOfferConstraints = options.rtcOfferConstraints || null;
+    const encodingsPriority = options.encodingsPriority || 'low';
 
     this._rtcOfferConstraints = rtcOfferConstraints;
     this._rtcAnswerConstraints = options.rtcAnswerConstraints || null;
@@ -395,7 +396,7 @@ module.exports = class RTCSession extends EventEmitter
 
     this._newRTCSession('local', this._request);
 
-    this._sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream);
+    this._sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream, encodingsPriority);
   }
 
   init_incoming(request, initCallback)
@@ -503,6 +504,24 @@ module.exports = class RTCSession extends EventEmitter
     this._progress('local', null);
   }
 
+  addStreamTracksWithPriority(stream, priority) {
+    logger.debug('Adding stream tracks with priority: %s', priority);
+    stream.getTracks().forEach((track) => {
+      let sender = this._connection.addTrack(track, stream);
+      const params = sender.getParameters();
+      params.encodings = params.encodings.map((e) => {
+        if (e.priority) {
+          e.priority = priority;
+        }
+        if (e.networkPriority) {
+          e.networkPriority = priority;
+        }
+        return e;
+      });
+      sender.setParameters(params);
+    });
+  }
+
   /**
    * Answer the call.
    */
@@ -518,6 +537,7 @@ module.exports = class RTCSession extends EventEmitter
     const rtcConstraints = options.rtcConstraints || null;
     const rtcAnswerConstraints = options.rtcAnswerConstraints || null;
     const rtcOfferConstraints = Utils.cloneObject(options.rtcOfferConstraints);
+    const encodingsPriority = options.encodingsPriority || 'low';
 
     let tracks;
     let peerHasAudioLine = false;
@@ -695,10 +715,7 @@ module.exports = class RTCSession extends EventEmitter
         this._localMediaStream = stream;
         if (stream)
         {
-          stream.getTracks().forEach((track) =>
-          {
-            this._connection.addTrack(track, stream);
-          });
+          this.addStreamTracksWithPriority(stream, encodingsPriority);
         }
       })
       // Set remote description.
@@ -2594,7 +2611,7 @@ module.exports = class RTCSession extends EventEmitter
   /**
    * Initial Request Sender
    */
-  _sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream)
+  _sendInitialRequest(mediaConstraints, rtcOfferConstraints, mediaStream, encodingsPriority)
   {
     const request_sender = new RequestSender(this._ua, this._request, {
       onRequestTimeout : () =>
@@ -2661,10 +2678,7 @@ module.exports = class RTCSession extends EventEmitter
 
         if (stream)
         {
-          stream.getTracks().forEach((track) =>
-          {
-            this._connection.addTrack(track, stream);
-          });
+          this.addStreamTracksWithPriority(stream, encodingsPriority);
         }
 
         // TODO: should this be triggered here?

--- a/lib/RTCSession.js
+++ b/lib/RTCSession.js
@@ -278,7 +278,7 @@ module.exports = class RTCSession extends EventEmitter
     const pcConfig = Utils.cloneObject(options.pcConfig, { iceServers: [] });
     const rtcConstraints = options.rtcConstraints || null;
     const rtcOfferConstraints = options.rtcOfferConstraints || null;
-    const encodingsPriority = options.encodingsPriority || 'low';
+    const encodingsPriority = options.encodingsPriority;
 
     this._rtcOfferConstraints = rtcOfferConstraints;
     this._rtcAnswerConstraints = options.rtcAnswerConstraints || null;
@@ -508,17 +508,19 @@ module.exports = class RTCSession extends EventEmitter
     logger.debug('Adding stream tracks with priority: %s', priority);
     stream.getTracks().forEach((track) => {
       let sender = this._connection.addTrack(track, stream);
-      const params = sender.getParameters();
-      params.encodings = params.encodings.map((e) => {
-        if (e.priority) {
-          e.priority = priority;
-        }
-        if (e.networkPriority) {
-          e.networkPriority = priority;
-        }
-        return e;
-      });
-      sender.setParameters(params);
+      if (priority && ['very-low', 'low', 'medium', 'high'].includes(priority)) {
+        const params = sender.getParameters();
+        params.encodings = params.encodings.map((e) => {
+          if (e.priority) {
+            e.priority = priority;
+          }
+          if (e.networkPriority) {
+            e.networkPriority = priority;
+          }
+          return e;
+        });
+        sender.setParameters(params);
+      }
     });
   }
 
@@ -537,7 +539,7 @@ module.exports = class RTCSession extends EventEmitter
     const rtcConstraints = options.rtcConstraints || null;
     const rtcAnswerConstraints = options.rtcAnswerConstraints || null;
     const rtcOfferConstraints = Utils.cloneObject(options.rtcOfferConstraints);
-    const encodingsPriority = options.encodingsPriority || 'low';
+    const encodingsPriority = options.encodingsPriority;
 
     let tracks;
     let peerHasAudioLine = false;


### PR DESCRIPTION
Addresses #873. Adds the option to set the [sender's priority](https://developer.mozilla.org/en-US/docs/Web/API/RTCRtpSender/setParameters#priority) when adding local media stream tracks to the peer connection in `RTCSession`.

I added an optional field called `encodingsPriority` to the options passed to `call()` and to `answer()`. When not passed, the default value is applied (`'low'`).

I tested this both on Chrome and Safari. While encodings setting appears successful in both, as it turns out, Safari doesn't actually apply the settings to the packet headers, as can be verified with Wireshark:

#### Chrome
<img width="350" alt="gc" src="https://github.com/user-attachments/assets/8a22b2b1-0931-48d3-8f20-a04233a87237" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/95286af0-9a46-45dc-bca7-94bd0af8e530" />

#### Safari
<img width="350" alt="saf" src="https://github.com/user-attachments/assets/2be6a6e3-63ca-4fba-9065-b24c985f3cc7" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2bd4641a-aef5-4f69-9c14-86ece1fae0ab" />

This appears to be a bug in Safari (verified both in v17.x and v18.x) and we're going to report it to Safari's bug tracker.

### Example usage
```js
const SESSION_OPTIONS = {
    mediaConstraints: {
        audio: true,
        video: false
    },
    encodingsPriority: 'high',
};

const newSession = jssip.call(uri, SESSION_OPTIONS);
```
