### PR TITLE
allow reg id and reg call id to be passed

### DIFF
--- a/lib/Registrator.js
+++ b/lib/Registrator.js
@@ -13,7 +13,7 @@ module.exports = class Registrator
   constructor(ua, transport)
   {
     // Force reg_id to 1.
-    this._reg_id = 1;
+    this._reg_id = ua.configuration.registration_id || 1;
 
     this._ua = ua;
     this._transport = transport;
@@ -22,7 +22,7 @@ module.exports = class Registrator
     this._expires = ua.configuration.register_expires;
 
     // Call-ID and CSeq values RFC3261 10.2.
-    this._call_id = Utils.createRandomToken(22);
+    this._call_id = ua.configuration.registration_call_id || Utils.createRandomToken(22);
     this._cseq = 0;
 
     this._to_uri = ua.configuration.uri;


### PR DESCRIPTION
Currently, upon page refresh, the registration request being sent does not use the same Call-Id header in the REGISTER request, hence the backend (FreeSWITCH) assumes it's a different connection and keeps the old connection also open for a while (when multi connection per user is enabled). The old connection goes off after a while, but for some time it will be in memory and calls will be attempted to these connections.

Hence this pr, which will allow the client to explicitly pass the call-id and reg id for the registration requests, so frontend can use the same reference even after the reloads.