### PR TITLE
Force LF end-of-line for all js/ts files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.js eol=lf
+*.ts eol=lf


### PR DESCRIPTION
Enforced by eslint "linebreak-style". When running on Windows with core.autocrlf=true, all the text files become CRLF.