### PR TITLE
Added esbuild task for building minified version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules/
+/dist/

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@eslint/js": "^9.39.2",
     "@types/debug": "^4.1.12",
     "@types/events": "^3.0.3",
+    "esbuild": "^0.27.2",
     "eslint": "^9.39.1",
     "eslint-plugin-jest": "^29.12.1",
     "globals": "^17.0.0",
@@ -45,6 +46,7 @@
   "scripts": {
     "lint": "node npm-scripts.js lint",
     "test": "node npm-scripts.js test",
+    "build": "node npm-scripts.js build",
     "release": "node npm-scripts.js release"
   }
 }


### PR DESCRIPTION
Hi,
I was looking to see if there was a minified version of jssip that could be downloaded
but it looks as if the scripts for generating one were removed from the source.

I've added one to npm-scripts.js / package.json that runs esbuild
This is quite a bit faster than the original Browserify
I've also added /dist/ to .gitignore since normally you wouldn't want to include minified code into the github repo directly

What should be possible after this, is to add a line to the release function to run the build
then you could add an entry to package.json to also copy /dist/jssip.min.js into the final package published to npmjs
This is the way I think most other packages tend to do it
