### PR TITLE
removing refer_to uri headers when creating target uri for INVITE - #970

### DIFF
--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -2314,7 +2314,8 @@ module.exports = class RTCSession extends EventEmitter {
 				options.extraHeaders.push(`Replaces: ${replaces}`);
 			}
 
-			let target_uri = request.refer_to.uri.clone();
+			const target_uri = request.refer_to.uri.clone();
+
 			target_uri.clearHeaders();
 			session.connect(target_uri, options, initCallback);
 		}

--- a/src/RTCSession.js
+++ b/src/RTCSession.js
@@ -2314,7 +2314,9 @@ module.exports = class RTCSession extends EventEmitter {
 				options.extraHeaders.push(`Replaces: ${replaces}`);
 			}
 
-			session.connect(request.refer_to.uri, options, initCallback);
+			let target_uri = request.refer_to.uri.clone();
+			target_uri.clearHeaders();
+			session.connect(target_uri, options, initCallback);
 		}
 
 		function reject() {


### PR DESCRIPTION
Pull request for my change concerning issue #970:

It will prevent that the URI headers in the refer_to URI are forwarded to the target in the request-URI or To header.